### PR TITLE
Implement State

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build
         run: |
           cd build
-          make
+          make -j$(nproc)
       - name: Install
         run: |
           cd build

--- a/src/datatypes/character/Character.cpp
+++ b/src/datatypes/character/Character.cpp
@@ -116,4 +116,14 @@ namespace spy::character {
         j.at("gadgets").get_to(c.gadgets);
     }
 
+    bool Character::operator==(const Character &rhs) const {
+        return std::tie(characterId, name, coordinates, movePoints, actionPoints, healthPoints, intelligencePoints,
+                        chips, properties, gadgets) ==
+               std::tie(rhs.characterId, rhs.name, rhs.coordinates, rhs.movePoints, rhs.actionPoints, rhs.healthPoints,
+                        rhs.intelligencePoints, rhs.chips, rhs.properties, rhs.gadgets);
+    }
+
+    bool Character::operator<(const Character &rhs) const {
+        return characterId < rhs.characterId;
+    }
 }  // namespace spy::character

--- a/src/datatypes/character/Character.hpp
+++ b/src/datatypes/character/Character.hpp
@@ -77,6 +77,13 @@ namespace spy::character {
 
             friend void from_json(const nlohmann::json &j, Character &c);
 
+            bool operator==(const Character &rhs) const;
+
+            /**
+             * Ordering of Character is done using the characterId UUID only.
+             */
+            bool operator<(const Character &rhs) const;
+
         private:
             spy::util::UUID characterId;
             std::string name;

--- a/src/datatypes/gadgets/Gadget.cpp
+++ b/src/datatypes/gadgets/Gadget.cpp
@@ -6,6 +6,8 @@
 
 namespace spy::gadget {
 
+    Gadget::Gadget(GadgetEnum type, int usagesLeft) : type(type), usagesLeft(usagesLeft) {}
+
     GadgetEnum Gadget::getType() const {
         return type;
     }

--- a/src/datatypes/gadgets/Gadget.cpp
+++ b/src/datatypes/gadgets/Gadget.cpp
@@ -27,4 +27,8 @@ namespace spy::gadget {
         j.at("GadgetEnum").get_to(g.type);
         j.at("usages").get_to(g.usagesLeft);
     }
+
+    bool Gadget::operator==(const Gadget &rhs) const {
+        return std::tie(type, usagesLeft) == std::tie(rhs.type, rhs.usagesLeft);
+    }
 }  // namespace spy::gadget

--- a/src/datatypes/gadgets/Gadget.hpp
+++ b/src/datatypes/gadgets/Gadget.hpp
@@ -16,19 +16,21 @@ namespace spy::gadget {
 
         explicit Gadget(GadgetEnum type) : type{type}, usagesLeft{0} {};
 
-        [[nodiscard]] GadgetEnum getType() const;
+            [[nodiscard]] GadgetEnum getType() const;
 
-        [[nodiscard]] int getUsagesLeft() const;
+            [[nodiscard]] int getUsagesLeft() const;
 
-        void setUsagesLeft(int newUsages);
+            void setUsagesLeft(int newUsages);
 
-        friend void to_json(nlohmann::json &j, const Gadget &g);
+            friend void to_json(nlohmann::json &j, const Gadget &g);
 
-        friend void from_json(const nlohmann::json &j, Gadget &g);
+            friend void from_json(const nlohmann::json &j, Gadget &g);
 
-    private:
-        GadgetEnum type;
-        int usagesLeft;
+            bool operator==(const Gadget &rhs) const;
+
+        private:
+            GadgetEnum type;
+            int usagesLeft;
     };
 }
 

--- a/src/datatypes/gadgets/Gadget.hpp
+++ b/src/datatypes/gadgets/Gadget.hpp
@@ -11,10 +11,10 @@
 namespace spy::gadget {
 
     class Gadget {
-    public:
-        Gadget() : type{GadgetEnum::INVALID}, usagesLeft{0} {};
+        public:
+            Gadget() : type{GadgetEnum::INVALID}, usagesLeft{0} {};
 
-        explicit Gadget(GadgetEnum type) : type{type}, usagesLeft{0} {};
+            explicit Gadget(GadgetEnum type) : type{type}, usagesLeft{0} {};
 
             [[nodiscard]] GadgetEnum getType() const;
 

--- a/src/datatypes/gadgets/Gadget.hpp
+++ b/src/datatypes/gadgets/Gadget.hpp
@@ -14,7 +14,7 @@ namespace spy::gadget {
         public:
             Gadget() : type{GadgetEnum::INVALID}, usagesLeft{0} {};
 
-            explicit Gadget(GadgetEnum type) : type{type}, usagesLeft{0} {};
+            explicit Gadget(GadgetEnum type, int usagesLeft = 0);
 
             [[nodiscard]] GadgetEnum getType() const;
 

--- a/src/datatypes/gameplay/State.cpp
+++ b/src/datatypes/gameplay/State.cpp
@@ -4,16 +4,92 @@
 
 #include "State.hpp"
 
+#include <utility>
+
 namespace spy::gameplay {
-    void to_json(nlohmann::json &/*j*/, const State &/*s*/) {
-
+    void to_json(nlohmann::json &j, const State &s) {
+        j["currentRound"] = s.currentRound;
+        j["map"] = s.map;
+        j["mySafeCombinations"] = s.mySafeCombinations;
+        j["characters"] = s.characters;
+        j["catCoordinates"] = s.catCoordinates;
+        j["janitorCoordinates"] = s.janitorCoordinates;
     }
 
-    void from_json(const nlohmann::json &/*j*/, State &/*s*/) {
+    void from_json(const nlohmann::json &j, State &s) {
+        j.at("currentRound").get_to(s.currentRound);
+        j.at("map").get_to(s.map);
+        j.at("mySafeCombinations").get_to(s.mySafeCombinations);
+        j.at("characters").get_to(s.characters);
 
+        auto catCoordinatesJson = j.find("catCoordinates");
+        if (catCoordinatesJson != j.end()) {
+            // Use setter instead of get_to to properly handle coordinates outside the map
+            s.setCatCoordinates(catCoordinatesJson->get<decltype(s.catCoordinates)>());
+        }
+
+        auto janitorCoordinatesJson = j.find("janitorCoordinates");
+        if (janitorCoordinatesJson != j.end()) {
+            // Use setter instead of get_to to properly handle coordinates outside the map
+            s.setJanitorCoordinates(janitorCoordinatesJson->get<decltype(s.janitorCoordinates)>());
+        }
     }
 
-    bool State::operator==(const State &/*rhs*/) const {
-        return true;
+
+    unsigned int State::getCurrentRound() const {
+        return currentRound;
     }
+
+    scenario::FieldMap State::getMap() const {
+        return map;
+    }
+
+    const std::set<int> &State::getMySafeCombinations() const {
+        return mySafeCombinations;
+    }
+
+    const std::set<spy::character::Character> &State::getCharacters() const {
+        return characters;
+    }
+
+    const std::optional<util::Point> &State::getCatCoordinates() const {
+        return catCoordinates;
+    }
+
+    const std::optional<util::Point> &State::getJanitorCoordinates() const {
+        return janitorCoordinates;
+    }
+
+    void State::setCatCoordinates(const std::optional<util::Point> &newCatCoordinates) {
+        if (newCatCoordinates && map.isInside(newCatCoordinates.value())) {
+            State::catCoordinates = newCatCoordinates;
+        } else {
+            catCoordinates.reset();
+        }
+    }
+
+    void State::setJanitorCoordinates(const std::optional<util::Point> &newJanitorCoordinates) {
+        if (newJanitorCoordinates && map.isInside(newJanitorCoordinates.value())) {
+            State::janitorCoordinates = newJanitorCoordinates;
+        } else {
+            janitorCoordinates.reset();
+        }
+    }
+
+    bool State::operator==(const State &rhs) const {
+        return std::tie(currentRound, map, mySafeCombinations, characters, catCoordinates, janitorCoordinates) ==
+               std::tie(rhs.currentRound, rhs.map, rhs.mySafeCombinations, rhs.characters, rhs.catCoordinates,
+                        rhs.janitorCoordinates);
+    }
+
+    State::State(unsigned int currentRound, scenario::FieldMap map, std::set<int> mySafeCombinations,
+                 std::set<character::Character> characters, const std::optional<util::Point> &catCoordinates,
+                 const std::optional<util::Point> &janitorCoordinates) :
+            currentRound(currentRound),
+            map(std::move(map)),
+            mySafeCombinations(std::move(mySafeCombinations)),
+            characters(std::move(characters)),
+            catCoordinates(catCoordinates),
+            janitorCoordinates(janitorCoordinates) {}
+
 }

--- a/src/datatypes/gameplay/State.hpp
+++ b/src/datatypes/gameplay/State.hpp
@@ -1,23 +1,66 @@
-//
-// Created by marco on 10.04.20.
-//
+/**
+ * @author Jonas
+ * @brief Entire state of the game
+ */
 
 #ifndef LIBCOMMON_STATE_HPP
 #define LIBCOMMON_STATE_HPP
 
 #include <nlohmann/json.hpp>
+#include <util/Point.hpp>
+#include <set>
+#include <datatypes/character/Character.hpp>
+#include <datatypes/scenario/FieldMap.hpp>
 
 namespace spy::gameplay {
     class State {
+        public:
+
+            State() = default;
+
+            State(unsigned int currentRound, scenario::FieldMap map, std::set<int> mySafeCombinations,
+                  std::set<character::Character> characters, const std::optional<util::Point> &catCoordinates,
+                  const std::optional<util::Point> &janitorCoordinates);
+
+            [[nodiscard]] unsigned int getCurrentRound() const;
+
+            [[nodiscard]] scenario::FieldMap getMap() const;
+
+            [[nodiscard]] const std::set<int> &getMySafeCombinations() const;
+
+            [[nodiscard]] const std::set<spy::character::Character> &getCharacters() const;
+
+            [[nodiscard]] const std::optional<util::Point> &getCatCoordinates() const;
+
+            [[nodiscard]] const std::optional<util::Point> &getJanitorCoordinates() const;
+
+            /**
+              * Sets the cat coordinates
+              * @brief Standard specifies that absence of cat can be indicated by coordinates outside the map, so this resets
+              * the catCoordinates optional if the coordinates are outside the map.
+              */
+            void setCatCoordinates(const std::optional<util::Point> &catCoordinates);
+
+            /**
+             * Sets the janitor coordinates
+             * @brief Standard specifies that absence of janitor can be indicated by coordinates outside the map, so this resets
+             * the janitorCoordinates optional if the coordinates are outside the map.
+             */
+            void setJanitorCoordinates(const std::optional<util::Point> &janitorCoordinates);
+
             friend void to_json(nlohmann::json &j, const State &s);
 
             friend void from_json(const nlohmann::json &j, State &s);
 
-        public:
             bool operator==(const State &rhs) const;
 
+        private:
+            unsigned int currentRound = 0;
+            scenario::FieldMap map;
+            std::set<int> mySafeCombinations;
+            std::set<character::Character> characters;
+            std::optional<util::Point> catCoordinates;
+            std::optional<util::Point> janitorCoordinates;
     };
 }
-
-
 #endif //LIBCOMMON_STATE_HPP

--- a/src/datatypes/scenario/Field.cpp
+++ b/src/datatypes/scenario/Field.cpp
@@ -177,4 +177,10 @@ namespace spy::scenario {
             j.at("isUpdated").get_to(f.updated);
         }
     }
+
+    bool Field::operator==(const Field &rhs) const {
+        return std::tie(state, gadget, destroyed, inverted, chipAmount, safeIndex, foggy, updated) ==
+               std::tie(rhs.state, rhs.gadget, rhs.destroyed, rhs.inverted, rhs.chipAmount, rhs.safeIndex, rhs.foggy,
+                        rhs.updated);
+    }
 }

--- a/src/datatypes/scenario/Field.hpp
+++ b/src/datatypes/scenario/Field.hpp
@@ -36,15 +36,22 @@ namespace spy::scenario {
             [[nodiscard]] FieldStateEnum getFieldState() const;
             [[nodiscard]] std::optional<bool> isDestroyed() const;
             [[nodiscard]] std::optional<bool> isUpdated() const;
+
             [[nodiscard]] std::optional<bool> isInverted() const;
+
             [[nodiscard]] bool isFoggy() const;
-            [[nodiscard]] const std::optional<Gadget>& getGadget() const;
+
+            [[nodiscard]] const std::optional<Gadget> &getGadget() const;
+
             [[nodiscard]] std::optional<unsigned int> getChipAmount() const;
+
             [[nodiscard]] std::optional<unsigned int> getSafeIndex() const;
 
             friend void to_json(nlohmann::json &j, const Field &f);
 
             friend void from_json(const nlohmann::json &j, Field &f);
+
+            bool operator==(const Field &rhs) const;
 
         private:
             FieldStateEnum state = FieldStateEnum::FREE;

--- a/src/datatypes/scenario/FieldMap.cpp
+++ b/src/datatypes/scenario/FieldMap.cpp
@@ -56,4 +56,8 @@ namespace spy::scenario {
     void from_json(const nlohmann::json &j, FieldMap &m) {
         j.at("fieldMap").get_to(m.map);
     }
+
+    bool FieldMap::operator==(const FieldMap &rhs) const {
+        return map == rhs.map;
+    }
 }

--- a/src/datatypes/scenario/FieldMap.hpp
+++ b/src/datatypes/scenario/FieldMap.hpp
@@ -42,6 +42,8 @@ namespace spy::scenario {
 
             friend void from_json(const nlohmann::json &j, FieldMap &m);
 
+            bool operator==(const FieldMap &rhs) const;
+
         private:
             std::vector<std::vector<Field>> map;
     };

--- a/test/messages/messageEncodeDecode.cpp
+++ b/test/messages/messageEncodeDecode.cpp
@@ -37,6 +37,14 @@ nlohmann::json exampleScenarioJson = R"({ "scenario": [
 	    ]})"_json;
 
 class MessageEncodeDecode : public ::testing::Test {
+    public:
+        MessageEncodeDecode() {
+            char1.setGadgets({spy::gadget::Gadget{spy::gadget::GadgetEnum::LASER_COMPACT, 3},
+                              spy::gadget::Gadget{spy::gadget::GadgetEnum::JETPACK, 4}});
+            exampleState = {7, exampleMap, {1337, 420}, {char1, char2}, spy::util::Point{1, 2},
+                            spy::util::Point{5, 1}};
+        }
+
     protected:
         spy::util::UUID exampleUUID1 = spy::util::UUID{"6a1333d0-2317-4044-9d37-047d29205011"};
         spy::util::UUID exampleUUID2 = spy::util::UUID{"6a1333d1-2318-5044-9d37-047d29205012"};
@@ -46,8 +54,7 @@ class MessageEncodeDecode : public ::testing::Test {
         spy::scenario::FieldMap exampleMap = spy::scenario::FieldMap{exampleScenario};
         spy::character::Character char1 = {exampleUUID1, "TestChar1"};
         spy::character::Character char2 = {exampleUUID2, "TestChar2"};
-        spy::gameplay::State exampleState = {7, exampleMap, {1337, 420}, {char1, char2}, spy::util::Point{1, 2},
-                                             spy::util::Point{5, 1}};
+        spy::gameplay::State exampleState;
 };
 
 

--- a/test/messages/messageEncodeDecode.cpp
+++ b/test/messages/messageEncodeDecode.cpp
@@ -26,10 +26,29 @@
 #include <network/messages/Strike.hpp>
 #include <network/messages/MetaInformation.hpp>
 
-auto exampleUUID1 = spy::util::UUID{"6a1333d0-2317-4044-9d37-047d29205011"};
-auto exampleUUID2 = spy::util::UUID{"6a1333d1-2318-5044-9d37-047d29205012"};
-auto exampleOperation = spy::gameplay::Operation{spy::gameplay::OperationEnum::MOVEMENT, true, {3, 3}, exampleUUID2};
-auto exampleState = spy::gameplay::State{};
+nlohmann::json exampleScenarioJson = R"({ "scenario": [
+		["WALL", "WALL",      "WALL", "WALL",           "WALL",     "WALL", "WALL"],
+		["WALL", "FIREPLACE", "WALL", "BAR_TABLE",      "BAR_SEAT", "FREE", "WALL"],
+		["WALL", "FREE",      "FREE", "FREE",           "FREE",     "FREE", "WALL"],
+		["WALL", "BAR_TABLE", "FREE", "ROULETTE_TABLE", "FREE",     "FREE", "WALL"],
+		["WALL", "BAR_SEAT",  "FREE", "WALL",           "FREE",     "FREE", "WALL"],
+		["WALL", "FREE",      "FREE", "FREE",           "FREE",     "SAFE", "WALL"],
+		["WALL", "WALL",      "WALL", "WALL",           "WALL",     "WALL", "WALL"]
+	    ]})"_json;
+
+class MessageEncodeDecode : public ::testing::Test {
+    protected:
+        spy::util::UUID exampleUUID1 = spy::util::UUID{"6a1333d0-2317-4044-9d37-047d29205011"};
+        spy::util::UUID exampleUUID2 = spy::util::UUID{"6a1333d1-2318-5044-9d37-047d29205012"};
+        spy::gameplay::Operation exampleOperation = {spy::gameplay::OperationEnum::MOVEMENT, true, {3, 3},
+                                                     exampleUUID2};
+        spy::scenario::Scenario exampleScenario = exampleScenarioJson.get<spy::scenario::Scenario>();
+        spy::scenario::FieldMap exampleMap = spy::scenario::FieldMap{exampleScenario};
+        spy::character::Character char1 = {exampleUUID1, "TestChar1"};
+        spy::character::Character char2 = {exampleUUID2, "TestChar2"};
+        spy::gameplay::State exampleState = {7, exampleMap, {1337, 420}, {char1, char2}, spy::util::Point{1, 2},
+                                             spy::util::Point{5, 1}};
+};
 
 
 template<typename MessageType>
@@ -48,7 +67,7 @@ void testEncodeDecode(const MessageType &message) {
     EXPECT_EQ(message, decodedMessage);
 }
 
-TEST(MessageEncodeDecode, EquipmentChoice) {
+TEST_F(MessageEncodeDecode, EquipmentChoice) {
     using namespace spy::gadget;
     std::set<GadgetEnum> chosenGadgets1 = {GadgetEnum::HAIRDRYER, GadgetEnum::JETPACK};
     std::set<GadgetEnum> chosenGadgets2 = {GadgetEnum::POISON_PILLS, GadgetEnum::FOG_TIN, GadgetEnum::LASER_COMPACT};
@@ -57,102 +76,102 @@ TEST(MessageEncodeDecode, EquipmentChoice) {
     testEncodeDecode(testMessage);
 }
 
-TEST(MessageEncodeDecode, Error) {
+TEST_F(MessageEncodeDecode, Error) {
     spy::network::messages::Error testMessage{exampleUUID1, spy::network::ErrorTypeEnum::TOO_MANY_STRIKES};
     testEncodeDecode(testMessage);
 }
 
-TEST(MessageEncodeDecode, GameLeave) {
+TEST_F(MessageEncodeDecode, GameLeave) {
     spy::network::messages::GameLeave testMessage{exampleUUID1};
     testEncodeDecode(testMessage);
 }
 
-TEST(MessageEncodeDecode, GameLeft) {
+TEST_F(MessageEncodeDecode, GameLeft) {
     spy::network::messages::GameLeft testMessage{exampleUUID1, exampleUUID2};
     testEncodeDecode(testMessage);
 }
 
-TEST(MessageEncodeDecode, GameOperation) {
+TEST_F(MessageEncodeDecode, GameOperation) {
     spy::network::messages::GameOperation testMessage{exampleUUID1, exampleOperation};
     testEncodeDecode(testMessage);
 }
 
-TEST(MessageEncodeDecode, GamePause) {
+TEST_F(MessageEncodeDecode, GamePause) {
     spy::network::messages::GamePause testMessage{exampleUUID1, true, false};
     testEncodeDecode(testMessage);
 }
 
-TEST(MessageEncodeDecode, GameStarted) {
+TEST_F(MessageEncodeDecode, GameStarted) {
     spy::network::messages::GameStarted testMessage{exampleUUID1, exampleUUID2, exampleUUID1, "P1", "P2", exampleUUID2};
     testEncodeDecode(testMessage);
 }
 
-TEST(MessageEncodeDecode, GameStatus) {
+TEST_F(MessageEncodeDecode, GameStatus) {
     spy::network::messages::GameStatus testMessage{exampleUUID1, exampleUUID2, {exampleOperation, exampleOperation},
                                                    exampleState, false};
     testEncodeDecode(testMessage);
 }
 
-TEST(MessageEncodeDecode, Hello) {
+TEST_F(MessageEncodeDecode, Hello) {
     spy::network::messages::Hello testMessage{exampleUUID1, "Name", spy::network::RoleEnum::PLAYER};
     testEncodeDecode(testMessage);
 }
 
-TEST(MessageEncodeDecode, HelloReply) {
+TEST_F(MessageEncodeDecode, HelloReply) {
     spy::network::messages::HelloReply testMessage{exampleUUID1, exampleUUID2, {}, {}, {{}}};
     testEncodeDecode(testMessage);
 }
 
-TEST(MessageEncodeDecode, ItemChoice) {
+TEST_F(MessageEncodeDecode, ItemChoice) {
     spy::network::messages::ItemChoice testMessage{exampleUUID1, exampleUUID2};
     testEncodeDecode(testMessage);
 }
 
-TEST(MessageEncodeDecode, ItemChoice_Gadget) {
+TEST_F(MessageEncodeDecode, ItemChoice_Gadget) {
     spy::network::messages::ItemChoice testMessage{exampleUUID1, spy::gadget::GadgetEnum::HAIRDRYER};
     testEncodeDecode(testMessage);
 }
 
-TEST(MessageEncodeDecode, Reconnect) {
+TEST_F(MessageEncodeDecode, Reconnect) {
     spy::network::messages::Reconnect testMessage{exampleUUID1, exampleUUID2};
     testEncodeDecode(testMessage);
 }
 
-TEST(MessageEncodeDecode, RequestEquipmentChoice) {
+TEST_F(MessageEncodeDecode, RequestEquipmentChoice) {
     spy::network::messages::RequestEquipmentChoice testMessage{exampleUUID1, {exampleUUID1, exampleUUID2},
                                                                {spy::gadget::GadgetEnum::LASER_COMPACT,
                                                                 spy::gadget::GadgetEnum::FOG_TIN}};
     testEncodeDecode(testMessage);
 }
 
-TEST(MessageEncodeDecode, RequestGameOperation) {
+TEST_F(MessageEncodeDecode, RequestGameOperation) {
     spy::network::messages::RequestGameOperation testMessage{exampleUUID1, exampleUUID2};
     testEncodeDecode(testMessage);
 }
 
-TEST(MessageEncodeDecode, RequestGamePause) {
+TEST_F(MessageEncodeDecode, RequestGamePause) {
     spy::network::messages::RequestGamePause testMessage{exampleUUID1, true};
     testEncodeDecode(testMessage);
 }
 
-TEST(MessageEncodeDecode, RequestItemChoice) {
+TEST_F(MessageEncodeDecode, RequestItemChoice) {
     spy::network::messages::RequestItemChoice testMessage{exampleUUID1, {exampleUUID1, exampleUUID2},
                                                           {spy::gadget::GadgetEnum::LASER_COMPACT,
                                                            spy::gadget::GadgetEnum::FOG_TIN}};
     testEncodeDecode(testMessage);
 }
 
-TEST(MessageEncodeDecode, RequestMetaInformation) {
+TEST_F(MessageEncodeDecode, RequestMetaInformation) {
     spy::network::messages::RequestMetaInformation testMessage{exampleUUID1, {"key1", "key2"}};
     testEncodeDecode(testMessage);
 }
 
-TEST(MessageEncodeDecode, RequestReplay) {
+TEST_F(MessageEncodeDecode, RequestReplay) {
     spy::network::messages::RequestReplay testMessage{exampleUUID1};
     testEncodeDecode(testMessage);
 }
 
-TEST(MessageEncodeDecode, StatisticsMessage) {
+TEST_F(MessageEncodeDecode, StatisticsMessage) {
     spy::network::messages::StatisticsMessage testMessage{exampleUUID1,
                                                           spy::statistics::Statistics{{{"Cocktails", "Who drank the most?", "17", "3"}}},
                                                           exampleUUID1,
@@ -160,12 +179,12 @@ TEST(MessageEncodeDecode, StatisticsMessage) {
     testEncodeDecode(testMessage);
 }
 
-TEST(MessageEncodeDecode, Strike) {
+TEST_F(MessageEncodeDecode, Strike) {
     spy::network::messages::Strike testMessage{exampleUUID1, 7, 8, "Stealing cocktails from players"};
     testEncodeDecode(testMessage);
 }
 
-TEST(MessageEncodeDecode, MetaInformation) {
+TEST_F(MessageEncodeDecode, MetaInformation) {
     using namespace spy::network::messages;
 
     MetaInformation testMessage{exampleUUID1, {{"Spectator.Count", 1},

--- a/test/messages/messageEncodeDecode.cpp
+++ b/test/messages/messageEncodeDecode.cpp
@@ -43,6 +43,9 @@ class MessageEncodeDecode : public ::testing::Test {
                               spy::gadget::Gadget{spy::gadget::GadgetEnum::JETPACK, 4}});
             exampleState = {7, exampleMap, {1337, 420}, {char1, char2}, spy::util::Point{1, 2},
                             spy::util::Point{5, 1}};
+            exampleState_noCat_noJanitor = exampleState;
+            exampleState_noCat_noJanitor.setJanitorCoordinates({{-1, -1}});
+            exampleState_noCat_noJanitor.setCatCoordinates(std::nullopt);
         }
 
     protected:
@@ -55,6 +58,7 @@ class MessageEncodeDecode : public ::testing::Test {
         spy::character::Character char1 = {exampleUUID1, "TestChar1"};
         spy::character::Character char2 = {exampleUUID2, "TestChar2"};
         spy::gameplay::State exampleState;
+        spy::gameplay::State exampleState_noCat_noJanitor;
 };
 
 
@@ -116,6 +120,10 @@ TEST_F(MessageEncodeDecode, GameStarted) {
 TEST_F(MessageEncodeDecode, GameStatus) {
     spy::network::messages::GameStatus testMessage{exampleUUID1, exampleUUID2, {exampleOperation, exampleOperation},
                                                    exampleState, false};
+    testEncodeDecode(testMessage);
+
+    testMessage = {exampleUUID1, exampleUUID2, {exampleOperation, exampleOperation},
+                   exampleState_noCat_noJanitor, false};
     testEncodeDecode(testMessage);
 }
 


### PR DESCRIPTION
fixes #46 

* Class spy::gameplay::State
* Character::operator< for std::set<Character> in State
* Character::operator== for State comparison
* Gadget::operator== for State comparison
* FieldMap::operator== for State comparison
* Field::operator== for FieldMap comparison
* State::operator== for unit tests
* Change message unit tests to use test fixture
* More comprehensive testState in messageEncodeDecode test