### PR TITLE
Implentation of creationDate in MessageContainer

### DIFF
--- a/src/network/MessageContainer.cpp
+++ b/src/network/MessageContainer.cpp
@@ -18,11 +18,11 @@ namespace spy::network {
     MessageContainer::MessageContainer(messages::MessageTypeEnum messageType, util::UUID playerId) :
             playerId(playerId),
             type(messageType) {
-        time_t rawtime = time(nullptr);
-        struct tm creationDateTM = *gmtime(&rawtime);
-        creationDateTM.tm_hour = (creationDateTM.tm_hour + 1) % 24;
+        std::time_t rawtime = std::time(nullptr);
+        struct std::tm *creationDateTM = std::gmtime(&rawtime);
+        creationDateTM->tm_hour = (creationDateTM->tm_hour + 1) % 24;
         char buffer[20];
-        strptime(buffer, "%d.%m.%Y %H:%M:%S", &creationDateTM);
+        std::strftime(buffer, sizeof(buffer), "%d.%m.%Y %H:%M:%S", creationDateTM);
         creationDate = std::string(buffer);
     }
 

--- a/src/network/MessageContainer.cpp
+++ b/src/network/MessageContainer.cpp
@@ -4,7 +4,7 @@
 
 #include "MessageContainer.hpp"
 #include <util/OptionalSerialization.hpp>
-#include <time.h>
+#include <ctime>
 
 namespace spy::network {
     void to_json(nlohmann::json &j, const MessageContainer &m) {

--- a/src/network/MessageContainer.cpp
+++ b/src/network/MessageContainer.cpp
@@ -20,7 +20,7 @@ namespace spy::network {
             type(messageType) {
         setenv("TZ", "Africa/Malabo", 1); // UTC+1 the whole year
         std::time_t rawtime = std::time(nullptr);
-        struct std::tm *creationDateTM = std::gmtime(&rawtime);
+        const struct std::tm *creationDateTM = localtime(&rawtime);
         char buffer[20];
         std::strftime(buffer, sizeof(buffer), "%d.%m.%Y %H:%M:%S", creationDateTM);
         creationDate = std::string(buffer);

--- a/src/network/MessageContainer.cpp
+++ b/src/network/MessageContainer.cpp
@@ -20,9 +20,10 @@ namespace spy::network {
             type(messageType) {
         setenv("TZ", "Africa/Malabo", 1); // UTC+1 the whole year
         std::time_t rawtime = std::time(nullptr);
-        const struct std::tm *creationDateTM = localtime(&rawtime);
+        struct std::tm creationDateTM;
+        localtime_r(&rawtime, &creationDateTM);
         char buffer[20];
-        std::strftime(buffer, sizeof(buffer), "%d.%m.%Y %H:%M:%S", creationDateTM);
+        std::strftime(buffer, sizeof(buffer), "%d.%m.%Y %H:%M:%S", &creationDateTM);
         creationDate = std::string(buffer);
     }
 

--- a/src/network/MessageContainer.cpp
+++ b/src/network/MessageContainer.cpp
@@ -18,9 +18,9 @@ namespace spy::network {
     MessageContainer::MessageContainer(messages::MessageTypeEnum messageType, util::UUID playerId) :
             playerId(playerId),
             type(messageType) {
+        setenv("TZ", "Africa/Malabo", 1); // UTC+1 the whole year
         std::time_t rawtime = std::time(nullptr);
         struct std::tm *creationDateTM = std::gmtime(&rawtime);
-        creationDateTM->tm_hour = (creationDateTM->tm_hour + 1) % 24;
         char buffer[20];
         std::strftime(buffer, sizeof(buffer), "%d.%m.%Y %H:%M:%S", creationDateTM);
         creationDate = std::string(buffer);

--- a/src/network/MessageContainer.hpp
+++ b/src/network/MessageContainer.hpp
@@ -8,7 +8,6 @@
 #include <util/UUID.hpp>
 #include <network/messages/MessageTypeEnum.hpp>
 #include <string>
-#include <chrono>
 #include <optional>
 #include <nlohmann/json.hpp>
 #include <util/OptionalSerialization.hpp>
@@ -25,7 +24,7 @@ namespace spy::network {
 
             [[nodiscard]] messages::MessageTypeEnum getType() const;
 
-            [[nodiscard]] const std::string &getCreationDate() const;
+            [[nodiscard]] const struct tm &getCreationDate() const;
 
             [[nodiscard]] const std::optional<std::string> &getDebugMessage() const;
 
@@ -58,8 +57,7 @@ namespace spy::network {
         private:
             spy::util::UUID playerId;
             messages::MessageTypeEnum type = messages::MessageTypeEnum::INVALID;
-            // TODO: std::chrono::system_clock::time_point creationDate;
-            std::string creationDate;
+            struct tm creationDate;
             std::optional<std::string> debugMessage;
 
     };

--- a/src/network/MessageContainer.hpp
+++ b/src/network/MessageContainer.hpp
@@ -24,7 +24,7 @@ namespace spy::network {
 
             [[nodiscard]] messages::MessageTypeEnum getType() const;
 
-            [[nodiscard]] const struct tm &getCreationDate() const;
+            [[nodiscard]] const std::string &getCreationDate() const;
 
             [[nodiscard]] const std::optional<std::string> &getDebugMessage() const;
 
@@ -57,7 +57,7 @@ namespace spy::network {
         private:
             spy::util::UUID playerId;
             messages::MessageTypeEnum type = messages::MessageTypeEnum::INVALID;
-            struct tm creationDate;
+            std::string creationDate;
             std::optional<std::string> debugMessage;
 
     };

--- a/test/messages/helloMessageTest.cpp
+++ b/test/messages/helloMessageTest.cpp
@@ -20,7 +20,8 @@ TEST(messages, helloMessage){
 
     nlohmann::json json = m;
     std::string serialized = json.dump();
-    std::string expected = R"({"creationDate":"","name":"name123","playerId":"00000000-0000-0000-0000-000000000000","role":"PLAYER","type":"HELLO"})";
+    std::string expected = R"({"creationDate":")" + m.getCreationDate() +
+            R"(","name":"name123","playerId":"00000000-0000-0000-0000-000000000000","role":"PLAYER","type":"HELLO"})";
     EXPECT_EQ(serialized, expected);
 
 

--- a/test/messages/itemChoiceMessageTest.cpp
+++ b/test/messages/itemChoiceMessageTest.cpp
@@ -13,7 +13,8 @@ TEST(messages, ItemChoiceMessage_encode_character) {
     nlohmann::json j;
     EXPECT_NO_THROW(j = characterChoice);
     EXPECT_EQ(j.dump(),
-              R"({"chosenCharacter":"123e4567-e89b-12d3-a456-426655441111","chosenGadget":null,"creationDate":"","playerId":"123e4567-e89b-12d3-a456-426655440000","type":"ITEM_CHOICE"})");
+              R"({"chosenCharacter":"123e4567-e89b-12d3-a456-426655441111","chosenGadget":null,"creationDate":")" +
+              characterChoice.getCreationDate() + R"(","playerId":"123e4567-e89b-12d3-a456-426655440000","type":"ITEM_CHOICE"})");
 }
 
 TEST(messages, ItemChoiceMessage_encode_gadget) {
@@ -24,7 +25,8 @@ TEST(messages, ItemChoiceMessage_encode_gadget) {
     nlohmann::json j;
     EXPECT_NO_THROW(j = gadgetChoice);
     EXPECT_EQ(j.dump(),
-              R"({"chosenCharacter":null,"chosenGadget":"POISON_PILLS","creationDate":"","playerId":"123e4567-e89b-12d3-a456-426655440000","type":"ITEM_CHOICE"})");
+              R"({"chosenCharacter":null,"chosenGadget":"POISON_PILLS","creationDate":")" +
+              gadgetChoice.getCreationDate() + R"(","playerId":"123e4567-e89b-12d3-a456-426655440000","type":"ITEM_CHOICE"})");
 }
 
 TEST(messages, ItemChoiceMessage_decode_character) {


### PR DESCRIPTION
Habe jetzt nicht chrono benutzt sondern ctime.
Nachdem in der kompletten Implementierung davon ausgegangen wurde, dass `creationDate` vom Typ `std::string` ist, habe ich das nachträglich beibehalten, da ich keinen Vorteil darin sehe das in einem "Zeittypen" anzulegen