### PR TITLE
Googletest for building in subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,27 +24,28 @@ add_subdirectory(src)
 
 option(LIBCOMMON_TESTS "Build the tests" ON)
 if (LIBCOMMON_TESTS)
-    # Download and unpack googletest at configure time
-    configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
-    execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-            RESULT_VARIABLE result
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download)
-    if (result)
-        message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+    if (NOT TARGET gtest)
+        # Download and unpack googletest at configure time
+        configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
+        execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+                RESULT_VARIABLE result
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download)
+        if (result)
+            message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+        endif ()
+
+        execute_process(COMMAND ${CMAKE_COMMAND} --build .
+                RESULT_VARIABLE result
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download)
+        if (result)
+            message(FATAL_ERROR "Build step for googletest failed: ${result}")
+        endif ()
+
+        # Add googletest directly to the build
+        add_subdirectory("${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+                "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
+                )
     endif ()
-
-    execute_process(COMMAND ${CMAKE_COMMAND} --build .
-            RESULT_VARIABLE result
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download)
-    if (result)
-        message(FATAL_ERROR "Build step for googletest failed: ${result}")
-    endif ()
-
-    # Add googletest directly to the build
-    add_subdirectory("${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
-            "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
-            )
-
     enable_testing()
     include(GoogleTest)
     add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,21 +28,21 @@ if (LIBCOMMON_TESTS)
     configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
     execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
             RESULT_VARIABLE result
-            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download)
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download)
     if (result)
         message(FATAL_ERROR "CMake step for googletest failed: ${result}")
     endif ()
 
     execute_process(COMMAND ${CMAKE_COMMAND} --build .
             RESULT_VARIABLE result
-            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download)
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download)
     if (result)
         message(FATAL_ERROR "Build step for googletest failed: ${result}")
     endif ()
 
     # Add googletest directly to the build
-    add_subdirectory("${CMAKE_BINARY_DIR}/googletest-src"
-            "${CMAKE_BINARY_DIR}/googletest-build"
+    add_subdirectory("${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+            "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
             )
 
     enable_testing()


### PR DESCRIPTION
replace CMAKE_BINARY_DIR with CMAKE_CURRENT_BINARY_DIR to correctly install googletest even when building in subdirectory

DIeser fix ermöglicht es LibCommon auch mit Tests zu bauen, auch wenn es mittels `add_subdirectory()` in ein anderes Projekt integriert ist.