### PR TITLE
Initial line of sight implementation

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,8 @@ sonar.projectKey=SoPra-Team-17_LibCommon
 sonar.host.url=https://sonarcloud.io
 
 sonar.cfamily.build-wrapper-output=bw-output
-sonar.sources=src,test
+sonar.sources=test
+sonar.tests=test
 sonar.cfamily.gcov.reportsPath=build
 
 sonar.cfamily.threads=4

--- a/src/datatypes/scenario/FieldMap.cpp
+++ b/src/datatypes/scenario/FieldMap.cpp
@@ -62,33 +62,29 @@ namespace spy::scenario {
 
         int dx = abs(p1.x - p2.x);
         int dy = abs(p1.y - p2.y);
-        util::Point curPoint = p1;
 
-        unsigned int fieldsToTraverse = dx + dy;
         int incX = (p2.x > p1.x) ? 1 : -1;
         int incY = (p2.y > p1.y) ? 1 : -1;
         int error = dx - dy;
-        dx *= 2;                                            // scaling is needed to make sure the error term is integral
+        // scaling is needed to make sure the error term is integral
+        dx *= 2;
         dy *= 2;
-
-        for (unsigned int fieldsVisited = 0; fieldsVisited < fieldsToTraverse; fieldsVisited++) {
-            if (curPoint != p2 && curPoint != p1 && blocksSight(curPoint)) {
+        auto currentPoint = p1;
+        while (currentPoint != p2) {
+            if (currentPoint != p1 && blocksSight(currentPoint)) {
                 return false;
             }
 
             if (error > 0) {
-                curPoint.x += incX;
+                currentPoint.x += incX;
                 error -= dy;
             } else if (error < 0) {
-                curPoint.y += incY;
+                currentPoint.y += incY;
                 error += dx;
             } else {
                 error -= dy;
                 error += dx;
-                curPoint.x += incX;
-                curPoint.y += incY;
-
-                fieldsVisited++;
+                currentPoint += {incX, incY};
             }
         }
 

--- a/src/datatypes/scenario/FieldMap.cpp
+++ b/src/datatypes/scenario/FieldMap.cpp
@@ -7,8 +7,6 @@
 
 #include "FieldMap.hpp"
 
-#include <iostream>
-
 namespace spy::scenario {
 
     FieldMap::FieldMap(const Scenario &scenario) {
@@ -62,13 +60,13 @@ namespace spy::scenario {
             return true;
         }
 
-        int dx = abs(p1.getX() - p2.getX());
-        int dy = abs(p1.getY() - p2.getY());
+        int dx = abs(p1.x - p2.x);
+        int dy = abs(p1.y - p2.y);
         util::Point curPoint = p1;
 
         unsigned int fieldsToTraverse = dx + dy;
-        int incX = (p2.getX() > p1.getX()) ? 1 : -1;
-        int incY = (p2.getY() > p1.getY()) ? 1 : -1;
+        int incX = (p2.x > p1.x) ? 1 : -1;
+        int incY = (p2.y > p1.y) ? 1 : -1;
         int error = dx - dy;
         dx *= 2;                                            // scaling is needed to make sure the error term is integral
         dy *= 2;
@@ -79,15 +77,16 @@ namespace spy::scenario {
             }
 
             if (error > 0) {
-                curPoint.setX(curPoint.getX() + incX);
+                curPoint.x += incX;
                 error -= dy;
             } else if (error < 0) {
-                curPoint.setY(curPoint.getY() + incY);
+                curPoint.y += incY;
                 error += dx;
             } else {
                 error -= dy;
                 error += dx;
-                curPoint.setLocation(curPoint.getX() + incX, curPoint.getY() + incY);
+                curPoint.x += incX;
+                curPoint.y += incY;
 
                 fieldsVisited++;
             }

--- a/src/datatypes/scenario/FieldMap.cpp
+++ b/src/datatypes/scenario/FieldMap.cpp
@@ -59,7 +59,7 @@ namespace spy::scenario {
         if (!isInside(p1) || !isInside(p2)) {
             throw std::invalid_argument("At least one point is outside the field map!");
         } else if (p1 == p2) {
-            throw std::invalid_argument("Points are identical!");
+            return true;
         }
 
         int dx = abs(p1.getX() - p2.getX());
@@ -74,9 +74,7 @@ namespace spy::scenario {
         dy *= 2;
 
         for (unsigned int fieldsVisited = 0; fieldsVisited < fieldsToTraverse; fieldsVisited++) {
-            if (curPoint == p2) {
-                break;
-            } else if (curPoint != p1 && blocksSight(curPoint)) {
+            if (curPoint != p2 && curPoint != p1 && blocksSight(curPoint)) {
                 return false;
             }
 
@@ -87,16 +85,9 @@ namespace spy::scenario {
                 curPoint.setY(curPoint.getY() + incY);
                 error += dx;
             } else {
-                int x = curPoint.getX();
-                int y = curPoint.getY();
-
-                if (blocksSight(util::Point(x + incX, y)) && blocksSight(util::Point(x, y + incY))) {
-                    return false;
-                }
-
                 error -= dy;
                 error += dx;
-                curPoint.setLocation(x + incX, y + incY);
+                curPoint.setLocation(curPoint.getX() + incX, curPoint.getY() + incY);
 
                 fieldsVisited++;
             }

--- a/src/datatypes/scenario/FieldMap.cpp
+++ b/src/datatypes/scenario/FieldMap.cpp
@@ -90,8 +90,7 @@ namespace spy::scenario {
                 int x = curPoint.getX();
                 int y = curPoint.getY();
 
-                if (isInside(p1) && blocksSight(util::Point(x + incX, y))
-                    && isInside(p2) && blocksSight(util::Point(x, y + incY))) {
+                if (blocksSight(util::Point(x + incX, y)) && blocksSight(util::Point(x, y + incY))) {
                     return false;
                 }
 

--- a/src/datatypes/scenario/FieldMap.cpp
+++ b/src/datatypes/scenario/FieldMap.cpp
@@ -83,7 +83,7 @@ namespace spy::scenario {
             if (error > 0) {
                 curPoint.setX(curPoint.getX() + incX);
                 error -= dy;
-            } else if (error < 0){
+            } else if (error < 0) {
                 curPoint.setY(curPoint.getY() + incY);
                 error += dx;
             } else {
@@ -107,7 +107,7 @@ namespace spy::scenario {
 
     bool FieldMap::blocksSight(util::Point p) const {
         return (getField(p).getFieldState() == FieldStateEnum::WALL
-               || getField(p).getFieldState() == FieldStateEnum::FIREPLACE);
+                || getField(p).getFieldState() == FieldStateEnum::FIREPLACE);
     }
 
     void to_json(nlohmann::json &j, const FieldMap &m) {

--- a/src/datatypes/scenario/FieldMap.hpp
+++ b/src/datatypes/scenario/FieldMap.hpp
@@ -38,6 +38,14 @@ namespace spy::scenario {
 
             [[nodiscard]] bool isInside(util::Point p) const;
 
+            /**
+             * Checks whether the line of sight between to fields is blocked.
+             * @param p1 First field.
+             * @param p2 Second field.
+             * @return False if the line of sight is blocked (by a fireplace or wall field), otherwise true.
+             */
+            [[nodiscard]] bool isLineOfSightFree(util::Point p1, util::Point p2) const;
+
             friend void to_json(nlohmann::json &j, const FieldMap &m);
 
             friend void from_json(const nlohmann::json &j, FieldMap &m);
@@ -45,6 +53,13 @@ namespace spy::scenario {
             bool operator==(const FieldMap &rhs) const;
 
         private:
+            /**
+             * Checks if a given field blocks the line of sight (thus is a wall or a fireplace).
+             * @param p Coordinate of the field to check.
+             * @return True if it blocks the line of sight, else false.
+             */
+            [[nodiscard]] bool blocksSight(util::Point p) const;
+
             std::vector<std::vector<Field>> map;
     };
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,7 +24,8 @@ set(SOURCES
         messages/itemChoiceMessageTest.cpp
         messages/metaInformationTest.cpp
         messages/messageEncodeDecode.cpp
-        messages/debugInfoTest.cpp)
+        messages/debugInfoTest.cpp
+        gameLogic/lineOfSightTests.cpp)
 
 add_executable(allTests ${SOURCES})
 

--- a/test/gameLogic/lineOfSightTests.cpp
+++ b/test/gameLogic/lineOfSightTests.cpp
@@ -38,6 +38,8 @@ TEST(LineOfSight, HorizontalLine) {
 
     EXPECT_FALSE(field.isLineOfSightFree({0, 0}, {2, 0}));
     EXPECT_TRUE(field.isLineOfSightFree({1, 3}, {1, 5}));
+    EXPECT_FALSE(field.isLineOfSightFree({2, 0}, {0, 0}));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 5}, {1, 3}));
 }
 
 TEST(LineOfSight, VerticalLine) {
@@ -48,6 +50,9 @@ TEST(LineOfSight, VerticalLine) {
 
     EXPECT_FALSE(field.isLineOfSightFree({0, 0}, {0, 2}));
     EXPECT_TRUE(field.isLineOfSightFree({4, 1}, {4, 5}));
+
+    EXPECT_FALSE(field.isLineOfSightFree({0, 2}, {0, 0}));
+    EXPECT_TRUE(field.isLineOfSightFree({4, 5}, {4, 1}));
 }
 
 TEST(LineOfSight, DiagonalLine) {
@@ -113,6 +118,64 @@ TEST(LineOfSight, DiagonalLine) {
 
     EXPECT_TRUE(field.isLineOfSightFree({3, 3}, {2, 4}));
     EXPECT_TRUE(field.isLineOfSightFree({2, 4}, {3, 5}));
+
+    EXPECT_FALSE(field.isLineOfSightFree({0, 0}, {1, 2}));
+    EXPECT_FALSE(field.isLineOfSightFree({1, 0}, {1, 2}));
+    EXPECT_FALSE(field.isLineOfSightFree({2, 0}, {1, 2}));
+    EXPECT_FALSE(field.isLineOfSightFree({3, 0}, {1, 2}));
+    EXPECT_FALSE(field.isLineOfSightFree({4, 0}, {1, 2}));
+    EXPECT_FALSE(field.isLineOfSightFree({5, 0}, {1, 2}));
+    EXPECT_FALSE(field.isLineOfSightFree({6, 0}, {1, 2}));
+
+    EXPECT_FALSE(field.isLineOfSightFree({0, 0}, {1, 2}));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 1}, {1, 2}));
+    EXPECT_TRUE(field.isLineOfSightFree({2, 1}, {1, 2}));
+    EXPECT_FALSE(field.isLineOfSightFree({3, 1}, {1, 2}));
+    EXPECT_TRUE(field.isLineOfSightFree({4, 1}, {1, 2}));
+    EXPECT_TRUE(field.isLineOfSightFree({5, 1}, {1, 2}));
+    EXPECT_TRUE(field.isLineOfSightFree({6, 1}, {1, 2}));
+
+    EXPECT_TRUE(field.isLineOfSightFree({0, 2}, {1, 2}));
+    EXPECT_TRUE(field.isLineOfSightFree({2, 2}, {1, 2}));
+    EXPECT_TRUE(field.isLineOfSightFree({3, 2}, {1, 2}));
+    EXPECT_TRUE(field.isLineOfSightFree({4, 2}, {1, 2}));
+    EXPECT_TRUE(field.isLineOfSightFree({5, 2}, {1, 2}));
+    EXPECT_TRUE(field.isLineOfSightFree({6, 2}, {1, 2}));
+
+    EXPECT_TRUE(field.isLineOfSightFree({0, 3}, {1, 2}));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 3}, {1, 2}));
+    EXPECT_TRUE(field.isLineOfSightFree({2, 3}, {1, 2}));
+    EXPECT_FALSE(field.isLineOfSightFree({3, 3}, {1, 2}));
+    EXPECT_TRUE(field.isLineOfSightFree({4, 3}, {1, 2}));
+    EXPECT_TRUE(field.isLineOfSightFree({5, 3}, {1, 2}));
+    EXPECT_TRUE(field.isLineOfSightFree({6, 3}, {1, 2}));
+
+    EXPECT_FALSE(field.isLineOfSightFree({0, 4}, {1, 2}));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 4}, {1, 2}));
+    EXPECT_FALSE(field.isLineOfSightFree({2, 4}, {1, 2}));
+    EXPECT_FALSE(field.isLineOfSightFree({3, 4}, {1, 2}));
+    EXPECT_FALSE(field.isLineOfSightFree({4, 4}, {1, 2}));
+    EXPECT_FALSE(field.isLineOfSightFree({5, 4}, {1, 2}));
+    EXPECT_FALSE(field.isLineOfSightFree({6, 4}, {1, 2}));
+
+    EXPECT_FALSE(field.isLineOfSightFree({0, 5}, {1, 2}));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 5}, {1, 2}));
+    EXPECT_TRUE(field.isLineOfSightFree({2, 5}, {1, 2}));
+    EXPECT_FALSE(field.isLineOfSightFree({3, 5}, {1, 2}));
+    EXPECT_FALSE(field.isLineOfSightFree({4, 5}, {1, 2}));
+    EXPECT_FALSE(field.isLineOfSightFree({5, 5}, {1, 2}));
+    EXPECT_FALSE(field.isLineOfSightFree({6, 5}, {1, 2}));
+
+    EXPECT_FALSE(field.isLineOfSightFree({0, 6}, {1, 2}));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 6}, {1, 2}));
+    EXPECT_TRUE(field.isLineOfSightFree({2, 6}, {1, 2}));
+    EXPECT_FALSE(field.isLineOfSightFree({3, 6}, {1, 2}));
+    EXPECT_FALSE(field.isLineOfSightFree({4, 6}, {1, 2}));
+    EXPECT_FALSE(field.isLineOfSightFree({5, 6}, {1, 2}));
+    EXPECT_FALSE(field.isLineOfSightFree({6, 6}, {1, 2}));
+
+    EXPECT_TRUE(field.isLineOfSightFree({2, 4}, {3, 3}));
+    EXPECT_TRUE(field.isLineOfSightFree({3, 5}, {2, 4}));
 }
 
 

--- a/test/gameLogic/lineOfSightTests.cpp
+++ b/test/gameLogic/lineOfSightTests.cpp
@@ -25,9 +25,9 @@ TEST(LineOfSight, InvalidArguments) {
 
     spy::scenario::FieldMap field(decodedScenario);
 
-    EXPECT_ANY_THROW(bool _ = field.isLineOfSightFree(spy::util::Point(-1, 0), spy::util::Point(0, 0)));
-    EXPECT_ANY_THROW(bool _ = field.isLineOfSightFree(spy::util::Point(0, 0), spy::util::Point(0, 7)));
-    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(0, 0), spy::util::Point(0, 0)));
+    EXPECT_ANY_THROW(bool _ = field.isLineOfSightFree({-1, 0}, {0, 0}));
+    EXPECT_ANY_THROW(bool _ = field.isLineOfSightFree({0, 0}, {0, 7}));
+    EXPECT_TRUE(field.isLineOfSightFree({0, 0}, {0, 0}));
 }
 
 TEST(LineOfSight, HorizontalLine) {
@@ -36,8 +36,8 @@ TEST(LineOfSight, HorizontalLine) {
 
     spy::scenario::FieldMap field(decodedScenario);
 
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(0, 0), spy::util::Point(2, 0)));
-    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 3), spy::util::Point(1, 5)));
+    EXPECT_FALSE(field.isLineOfSightFree({0, 0}, {2, 0}));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 3}, {1, 5}));
 }
 
 TEST(LineOfSight, VerticalLine) {
@@ -46,8 +46,8 @@ TEST(LineOfSight, VerticalLine) {
 
     spy::scenario::FieldMap field(decodedScenario);
 
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(0, 0), spy::util::Point(0, 2)));
-    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(4, 1), spy::util::Point(4, 5)));
+    EXPECT_FALSE(field.isLineOfSightFree({0, 0}, {0, 2}));
+    EXPECT_TRUE(field.isLineOfSightFree({4, 1}, {4, 5}));
 }
 
 TEST(LineOfSight, DiagonalLine) {
@@ -56,63 +56,63 @@ TEST(LineOfSight, DiagonalLine) {
 
     spy::scenario::FieldMap field(decodedScenario);
 
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(0, 0)));
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(1, 0)));
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(2, 0)));
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(3, 0)));
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(4, 0)));
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(5, 0)));
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(6, 0)));
+    EXPECT_FALSE(field.isLineOfSightFree({1, 2}, {0, 0}));
+    EXPECT_FALSE(field.isLineOfSightFree({1, 2}, {1, 0}));
+    EXPECT_FALSE(field.isLineOfSightFree({1, 2}, {2, 0}));
+    EXPECT_FALSE(field.isLineOfSightFree({1, 2}, {3, 0}));
+    EXPECT_FALSE(field.isLineOfSightFree({1, 2}, {4, 0}));
+    EXPECT_FALSE(field.isLineOfSightFree({1, 2}, {5, 0}));
+    EXPECT_FALSE(field.isLineOfSightFree({1, 2}, {6, 0}));
 
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(0, 0)));
-    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(1, 1)));
-    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(2, 1)));
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(3, 1)));
-    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(4, 1)));
-    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(5, 1)));
-    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(6, 1)));
+    EXPECT_FALSE(field.isLineOfSightFree({1, 2}, {0, 0}));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 2}, {1, 1}));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 2}, {2, 1}));
+    EXPECT_FALSE(field.isLineOfSightFree({1, 2}, {3, 1}));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 2}, {4, 1}));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 2}, {5, 1}));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 2}, {6, 1}));
 
-    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(0, 2)));
-    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(2, 2)));
-    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(3, 2)));
-    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(4, 2)));
-    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(5, 2)));
-    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(6, 2)));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 2}, {0, 2}));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 2}, {2, 2}));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 2}, {3, 2}));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 2}, {4, 2}));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 2}, {5, 2}));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 2}, {6, 2}));
 
-    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(0, 3)));
-    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(1, 3)));
-    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(2, 3)));
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(3, 3)));
-    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(4, 3)));
-    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(5, 3)));
-    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(6, 3)));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 2}, {0, 3}));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 2}, {1, 3}));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 2}, {2, 3}));
+    EXPECT_FALSE(field.isLineOfSightFree({1, 2}, {3, 3}));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 2}, {4, 3}));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 2}, {5, 3}));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 2}, {6, 3}));
 
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(0, 4)));
-    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(1, 4)));
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(2, 4)));
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(3, 4)));
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(4, 4)));
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(5, 4)));
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(6, 4)));
+    EXPECT_FALSE(field.isLineOfSightFree({1, 2}, {0, 4}));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 2}, {1, 4}));
+    EXPECT_FALSE(field.isLineOfSightFree({1, 2}, {2, 4}));
+    EXPECT_FALSE(field.isLineOfSightFree({1, 2}, {3, 4}));
+    EXPECT_FALSE(field.isLineOfSightFree({1, 2}, {4, 4}));
+    EXPECT_FALSE(field.isLineOfSightFree({1, 2}, {5, 4}));
+    EXPECT_FALSE(field.isLineOfSightFree({1, 2}, {6, 4}));
 
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(0, 5)));
-    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(1, 5)));
-    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(2, 5)));
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(3, 5)));
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(4, 5)));
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(5, 5)));
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(6, 5)));
+    EXPECT_FALSE(field.isLineOfSightFree({1, 2}, {0, 5}));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 2}, {1, 5}));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 2}, {2, 5}));
+    EXPECT_FALSE(field.isLineOfSightFree({1, 2}, {3, 5}));
+    EXPECT_FALSE(field.isLineOfSightFree({1, 2}, {4, 5}));
+    EXPECT_FALSE(field.isLineOfSightFree({1, 2}, {5, 5}));
+    EXPECT_FALSE(field.isLineOfSightFree({1, 2}, {6, 5}));
 
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(0, 6)));
-    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(1, 6)));
-    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(2, 6)));
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(3, 6)));
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(4, 6)));
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(5, 6)));
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(6, 6)));
+    EXPECT_FALSE(field.isLineOfSightFree({1, 2}, {0, 6}));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 2}, {1, 6}));
+    EXPECT_TRUE(field.isLineOfSightFree({1, 2}, {2, 6}));
+    EXPECT_FALSE(field.isLineOfSightFree({1, 2}, {3, 6}));
+    EXPECT_FALSE(field.isLineOfSightFree({1, 2}, {4, 6}));
+    EXPECT_FALSE(field.isLineOfSightFree({1, 2}, {5, 6}));
+    EXPECT_FALSE(field.isLineOfSightFree({1, 2}, {6, 6}));
 
-    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(3, 3), spy::util::Point(2, 4)));
-    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(2, 4), spy::util::Point(3, 5)));
+    EXPECT_TRUE(field.isLineOfSightFree({3, 3}, {2, 4}));
+    EXPECT_TRUE(field.isLineOfSightFree({2, 4}, {3, 5}));
 }
 
 

--- a/test/gameLogic/lineOfSightTests.cpp
+++ b/test/gameLogic/lineOfSightTests.cpp
@@ -27,7 +27,7 @@ TEST(LineOfSight, InvalidArguments) {
 
     EXPECT_ANY_THROW(bool _ = field.isLineOfSightFree(spy::util::Point(-1, 0), spy::util::Point(0, 0)));
     EXPECT_ANY_THROW(bool _ = field.isLineOfSightFree(spy::util::Point(0, 0), spy::util::Point(0, 7)));
-    EXPECT_ANY_THROW(bool _ = field.isLineOfSightFree(spy::util::Point(0, 0), spy::util::Point(0, 0)));
+    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(0, 0), spy::util::Point(0, 0)));
 }
 
 TEST(LineOfSight, HorizontalLine) {
@@ -111,7 +111,7 @@ TEST(LineOfSight, DiagonalLine) {
     EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(5, 6)));
     EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(6, 6)));
 
-    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(3, 3), spy::util::Point(2, 4)));
+    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(3, 3), spy::util::Point(2, 4)));
     EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(2, 4), spy::util::Point(3, 5)));
 }
 

--- a/test/gameLogic/lineOfSightTests.cpp
+++ b/test/gameLogic/lineOfSightTests.cpp
@@ -1,0 +1,119 @@
+/**
+ * @file   lineOfSightTests.cpp
+ * @author Dominik Authaler
+ * @date   19.04.2020 (creation)
+ * @brief  Unit tests for the line of sight implementation.
+ */
+
+#include <gtest/gtest.h>
+#include <scenario/Scenario.hpp>
+#include <scenario/FieldMap.hpp>
+
+auto input = R"({ "scenario": [
+            ["WALL", "WALL",      "WALL", "WALL",           "WALL",     "WALL", "WALL"],
+            ["WALL", "FIREPLACE", "WALL", "BAR_TABLE",      "BAR_SEAT", "FREE", "WALL"],
+            ["WALL", "FREE",      "FREE", "FREE",           "FREE",     "FREE", "WALL"],
+            ["WALL", "BAR_TABLE", "WALL", "ROULETTE_TABLE", "FREE",     "FREE", "WALL"],
+            ["WALL", "BAR_SEAT",  "FREE", "WALL",           "FREE",     "FREE", "WALL"],
+            ["WALL", "FREE",      "FREE", "FREE",           "FREE",     "SAFE", "WALL"],
+            ["WALL", "WALL",      "WALL", "WALL",           "WALL",     "WALL", "WALL"]
+            ]})"_json;
+
+TEST(LineOfSight, InvalidArguments) {
+    spy::scenario::Scenario decodedScenario;
+    decodedScenario = input.get<spy::scenario::Scenario>();
+
+    spy::scenario::FieldMap field(decodedScenario);
+
+    EXPECT_ANY_THROW(bool _ = field.isLineOfSightFree(spy::util::Point(-1, 0), spy::util::Point(0, 0)));
+    EXPECT_ANY_THROW(bool _ = field.isLineOfSightFree(spy::util::Point(0, 0), spy::util::Point(0, 7)));
+    EXPECT_ANY_THROW(bool _ = field.isLineOfSightFree(spy::util::Point(0, 0), spy::util::Point(0, 0)));
+}
+
+TEST(LineOfSight, HorizontalLine) {
+    spy::scenario::Scenario decodedScenario;
+    decodedScenario = input.get<spy::scenario::Scenario>();
+
+    spy::scenario::FieldMap field(decodedScenario);
+
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(0, 0), spy::util::Point(2, 0)));
+    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 3), spy::util::Point(1, 5)));
+}
+
+TEST(LineOfSight, VerticalLine) {
+    spy::scenario::Scenario decodedScenario;
+    decodedScenario = input.get<spy::scenario::Scenario>();
+
+    spy::scenario::FieldMap field(decodedScenario);
+
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(0, 0), spy::util::Point(0, 2)));
+    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(4, 1), spy::util::Point(4, 5)));
+}
+
+TEST(LineOfSight, DiagonalLine) {
+    spy::scenario::Scenario decodedScenario;
+    decodedScenario = input.get<spy::scenario::Scenario>();
+
+    spy::scenario::FieldMap field(decodedScenario);
+
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(0, 0)));
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(1, 0)));
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(2, 0)));
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(3, 0)));
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(4, 0)));
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(5, 0)));
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(6, 0)));
+
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(0, 0)));
+    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(1, 1)));
+    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(2, 1)));
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(3, 1)));
+    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(4, 1)));
+    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(5, 1)));
+    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(6, 1)));
+
+    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(0, 2)));
+    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(2, 2)));
+    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(3, 2)));
+    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(4, 2)));
+    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(5, 2)));
+    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(6, 2)));
+
+    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(0, 3)));
+    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(1, 3)));
+    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(2, 3)));
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(3, 3)));
+    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(4, 3)));
+    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(5, 3)));
+    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(6, 3)));
+
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(0, 4)));
+    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(1, 4)));
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(2, 4)));
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(3, 4)));
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(4, 4)));
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(5, 4)));
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(6, 4)));
+
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(0, 5)));
+    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(1, 5)));
+    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(2, 5)));
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(3, 5)));
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(4, 5)));
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(5, 5)));
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(6, 5)));
+
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(0, 6)));
+    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(1, 6)));
+    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(2, 6)));
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(3, 6)));
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(4, 6)));
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(5, 6)));
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(1, 2), spy::util::Point(6, 6)));
+
+    EXPECT_FALSE(field.isLineOfSightFree(spy::util::Point(3, 3), spy::util::Point(2, 4)));
+    EXPECT_TRUE(field.isLineOfSightFree(spy::util::Point(2, 4), spy::util::Point(3, 5)));
+}
+
+
+


### PR DESCRIPTION
Fixes #65.

Das Lastenheft ist bei der Definition aus meiner Sicht etwas ungenau, was folgenden Sonderfall angeht:

Wall Free                                                
Free Wall 


Wall Free                                              
Free Free

In der aktuellen Implementierung wurde für den oberen Fall angenommen, dass man von einem der freien Felder das jeweils andere nicht sehen kann. Im unteren Fall sind die Felder auf der Diagonale sichtbar, da nur eine Wand tangiert wird. 
Wie interpretiert ihr die Definition der Sichtlinie im Lastenheft?

