### PR TITLE
make util::Point members public

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,8 @@ sonar.projectKey=SoPra-Team-17_LibCommon
 sonar.host.url=https://sonarcloud.io
 
 sonar.cfamily.build-wrapper-output=bw-output
-sonar.sources=src,test
+sonar.sources=src
+sonar.tests=test
 sonar.cfamily.gcov.reportsPath=build
 
 sonar.cfamily.threads=4

--- a/src/datatypes/character/Character.cpp
+++ b/src/datatypes/character/Character.cpp
@@ -105,7 +105,7 @@ namespace spy::character {
         if (j.find("coordinates") != j.end()) {
             util::Point p;
             j.at("coordinates").get_to(p);
-            c.coordinates = (p.getX() < 0 || p.getY() < 0) ? std::optional<util::Point>() : p;
+            c.coordinates = (p.x < 0 || p.y < 0) ? std::optional<util::Point>() : p;
         }
         j.at("mp").get_to(c.movePoints);
         j.at("ap").get_to(c.actionPoints);

--- a/src/datatypes/scenario/FieldMap.cpp
+++ b/src/datatypes/scenario/FieldMap.cpp
@@ -28,7 +28,7 @@ namespace spy::scenario {
     }
 
     void FieldMap::setField(spy::util::Point p, spy::scenario::Field field) {
-        FieldMap::setField(p.getX(), p.getY(), field);
+        FieldMap::setField(p.x, p.y, field);
     }
 
     const std::vector<std::vector<Field>> &FieldMap::getMap() const {
@@ -40,13 +40,13 @@ namespace spy::scenario {
     }
 
     const Field &spy::scenario::FieldMap::getField(util::Point p) const {
-        return getField(p.getX(), p.getY());
+        return getField(p.x, p.y);
     }
 
     bool FieldMap::isInside(util::Point p) const {
-        return !(p.getX() < 0 || p.getY() < 0
-                 || map.size() <= static_cast<unsigned int>(p.getY())
-                 || map.at(p.getY()).size() <= static_cast<unsigned int>(p.getX()));
+        return !(p.x < 0 || p.y < 0
+                 || map.size() <= static_cast<unsigned int>(p.y)
+                 || map.at(p.y).size() <= static_cast<unsigned int>(p.x));
     }
 
     void to_json(nlohmann::json &j, const FieldMap &m) {

--- a/src/datatypes/scenario/Scenario.cpp
+++ b/src/datatypes/scenario/Scenario.cpp
@@ -14,7 +14,7 @@ namespace spy::scenario {
     }
 
     void Scenario::setField(util::Point p, FieldStateEnum field) {
-        setField(p.getX(), p.getY(), field);
+        setField(p.x, p.y, field);
     }
 
     FieldStateEnum Scenario::getField(unsigned int x, unsigned int y) const {
@@ -22,7 +22,7 @@ namespace spy::scenario {
     }
 
     FieldStateEnum Scenario::getField(util::Point p) const {
-        return getField(p.getX(), p.getY());
+        return getField(p.x, p.y);
     }
 
     const std::vector<std::vector<FieldStateEnum>> &Scenario::getScenario() const {

--- a/src/util/Point.cpp
+++ b/src/util/Point.cpp
@@ -8,43 +8,23 @@
 #include "Point.hpp"
 
 namespace spy::util {
-    Point::Point(int x, int y) : x(x), y(y) {}
-
-    int Point::getX() const {
-        return x;
-    }
-
-    void Point::setX(int xCord) {
-        Point::x = xCord;
-    }
-
-    int Point::getY() const {
-        return y;
-    }
-
-    void Point::setY(int yCord) {
-        Point::y = yCord;
-    }
-
-    void Point::setLocation(int xCoord, int yCoord) {
-        Point::x = xCoord;
-        Point::y = yCoord;
-    }
 
     void Point::operator+=(const Point &rhs) {
-        setLocation(Point::x + rhs.x, Point::y + rhs.y);
+        x += rhs.x;
+        y += rhs.y;
     }
 
     void Point::operator-=(const Point &rhs) {
-        setLocation(Point::x - rhs.x, Point::y - rhs.y);
+        x -= rhs.x;
+        y -= rhs.y;
     }
 
     Point Point::operator+(const Point &rhs) const {
-        return Point(this->x + rhs.x, this->y + rhs.y);
+        return {this->x + rhs.x, this->y + rhs.y};
     }
 
     Point Point::operator-(const Point &rhs) const {
-        return Point(this->x - rhs.x, this->y - rhs.y);
+        return {this->x - rhs.x, this->y - rhs.y};
     }
 
     bool Point::operator==(const Point &other) const {

--- a/src/util/Point.hpp
+++ b/src/util/Point.hpp
@@ -16,25 +16,6 @@ namespace spy::util {
      */
     class Point {
         public:
-            Point() = default;
-
-            Point(int x, int y);
-
-            [[nodiscard]] int getX() const;
-
-            void setX(int xCoord);
-
-            [[nodiscard]] int getY() const;
-
-            void setY(int yCoord);
-
-            /**
-             * Set x and y value of Point
-             * @param xCoord new x value of Point
-             * @param yCoord new y value of Point
-             */
-            void setLocation(int xCoord, int yCoord);
-
             void operator+=(const Point &rhs);
 
             void operator-=(const Point &rhs);
@@ -53,10 +34,8 @@ namespace spy::util {
 
             friend void from_json(const nlohmann::json &j, Point &p);
 
-        private:
             int x = 0;
             int y = 0;
-
     };
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,6 +27,12 @@ set(SOURCES
         messages/debugInfoTest.cpp)
 
 add_executable(allTests ${SOURCES})
-
-target_link_libraries(allTests gtest gmock gtest_main SopraCommon nlohmann_json::nlohmann_json)
+target_compile_options(allTests PRIVATE ${COMMON_CXX_FLAGS})
+target_link_libraries(allTests
+        gtest
+        gmock
+        gtest_main
+        SopraCommon
+        nlohmann_json::nlohmann_json
+        $<$<CONFIG:Debug>:--coverage>)
 gtest_discover_tests(allTests)

--- a/test/datatypes/scenarioTest.cpp
+++ b/test/datatypes/scenarioTest.cpp
@@ -55,29 +55,29 @@ TEST(Scenario, ScenarioDecodingEncoding) {
     EXPECT_EQ(decodedScenario.getField(5, 3), spy::scenario::FieldStateEnum::FREE);
     EXPECT_EQ(decodedScenario.getField(6, 3), spy::scenario::FieldStateEnum::WALL);
 
-    EXPECT_EQ(decodedScenario.getField(spy::util::Point(0, 4)), spy::scenario::FieldStateEnum::WALL);
-    EXPECT_EQ(decodedScenario.getField(spy::util::Point(1, 4)), spy::scenario::FieldStateEnum::BAR_SEAT);
-    EXPECT_EQ(decodedScenario.getField(spy::util::Point(2, 4)), spy::scenario::FieldStateEnum::FREE);
-    EXPECT_EQ(decodedScenario.getField(spy::util::Point(3, 4)), spy::scenario::FieldStateEnum::WALL);
-    EXPECT_EQ(decodedScenario.getField(spy::util::Point(4, 4)), spy::scenario::FieldStateEnum::FREE);
-    EXPECT_EQ(decodedScenario.getField(spy::util::Point(5, 4)), spy::scenario::FieldStateEnum::FREE);
-    EXPECT_EQ(decodedScenario.getField(spy::util::Point(6, 4)), spy::scenario::FieldStateEnum::WALL);
+    EXPECT_EQ(decodedScenario.getField({0, 4}), spy::scenario::FieldStateEnum::WALL);
+    EXPECT_EQ(decodedScenario.getField({1, 4}), spy::scenario::FieldStateEnum::BAR_SEAT);
+    EXPECT_EQ(decodedScenario.getField({2, 4}), spy::scenario::FieldStateEnum::FREE);
+    EXPECT_EQ(decodedScenario.getField({3, 4}), spy::scenario::FieldStateEnum::WALL);
+    EXPECT_EQ(decodedScenario.getField({4, 4}), spy::scenario::FieldStateEnum::FREE);
+    EXPECT_EQ(decodedScenario.getField({5, 4}), spy::scenario::FieldStateEnum::FREE);
+    EXPECT_EQ(decodedScenario.getField({6, 4}), spy::scenario::FieldStateEnum::WALL);
 
-    EXPECT_EQ(decodedScenario.getField(spy::util::Point(0, 5)), spy::scenario::FieldStateEnum::WALL);
-    EXPECT_EQ(decodedScenario.getField(spy::util::Point(1, 5)), spy::scenario::FieldStateEnum::FREE);
-    EXPECT_EQ(decodedScenario.getField(spy::util::Point(2, 5)), spy::scenario::FieldStateEnum::FREE);
-    EXPECT_EQ(decodedScenario.getField(spy::util::Point(3, 5)), spy::scenario::FieldStateEnum::FREE);
-    EXPECT_EQ(decodedScenario.getField(spy::util::Point(4, 5)), spy::scenario::FieldStateEnum::FREE);
-    EXPECT_EQ(decodedScenario.getField(spy::util::Point(5, 5)), spy::scenario::FieldStateEnum::SAFE);
-    EXPECT_EQ(decodedScenario.getField(spy::util::Point(6, 5)), spy::scenario::FieldStateEnum::WALL);
+    EXPECT_EQ(decodedScenario.getField({0, 5}), spy::scenario::FieldStateEnum::WALL);
+    EXPECT_EQ(decodedScenario.getField({1, 5}), spy::scenario::FieldStateEnum::FREE);
+    EXPECT_EQ(decodedScenario.getField({2, 5}), spy::scenario::FieldStateEnum::FREE);
+    EXPECT_EQ(decodedScenario.getField({3, 5}), spy::scenario::FieldStateEnum::FREE);
+    EXPECT_EQ(decodedScenario.getField({4, 5}), spy::scenario::FieldStateEnum::FREE);
+    EXPECT_EQ(decodedScenario.getField({5, 5}), spy::scenario::FieldStateEnum::SAFE);
+    EXPECT_EQ(decodedScenario.getField({6, 5}), spy::scenario::FieldStateEnum::WALL);
 
-    EXPECT_EQ(decodedScenario.getField(spy::util::Point(0, 6)), spy::scenario::FieldStateEnum::WALL);
-    EXPECT_EQ(decodedScenario.getField(spy::util::Point(1, 6)), spy::scenario::FieldStateEnum::WALL);
-    EXPECT_EQ(decodedScenario.getField(spy::util::Point(2, 6)), spy::scenario::FieldStateEnum::WALL);
-    EXPECT_EQ(decodedScenario.getField(spy::util::Point(3, 6)), spy::scenario::FieldStateEnum::WALL);
-    EXPECT_EQ(decodedScenario.getField(spy::util::Point(4, 6)), spy::scenario::FieldStateEnum::WALL);
-    EXPECT_EQ(decodedScenario.getField(spy::util::Point(5, 6)), spy::scenario::FieldStateEnum::WALL);
-    EXPECT_EQ(decodedScenario.getField(spy::util::Point(6, 6)), spy::scenario::FieldStateEnum::WALL);
+    EXPECT_EQ(decodedScenario.getField({0, 6}), spy::scenario::FieldStateEnum::WALL);
+    EXPECT_EQ(decodedScenario.getField({1, 6}), spy::scenario::FieldStateEnum::WALL);
+    EXPECT_EQ(decodedScenario.getField({2, 6}), spy::scenario::FieldStateEnum::WALL);
+    EXPECT_EQ(decodedScenario.getField({3, 6}), spy::scenario::FieldStateEnum::WALL);
+    EXPECT_EQ(decodedScenario.getField({4, 6}), spy::scenario::FieldStateEnum::WALL);
+    EXPECT_EQ(decodedScenario.getField({5, 6}), spy::scenario::FieldStateEnum::WALL);
+    EXPECT_EQ(decodedScenario.getField({6, 6}), spy::scenario::FieldStateEnum::WALL);
 
     nlohmann::json json;
     EXPECT_NO_THROW(json = decodedScenario);
@@ -132,29 +132,29 @@ TEST(Scenario, FieldMapConstruction) {
     EXPECT_EQ(field.getField(5, 3).getFieldState(), spy::scenario::FieldStateEnum::FREE);
     EXPECT_EQ(field.getField(6, 3).getFieldState(), spy::scenario::FieldStateEnum::WALL);
 
-    EXPECT_EQ(field.getField(spy::util::Point(0, 4)).getFieldState(), spy::scenario::FieldStateEnum::WALL);
-    EXPECT_EQ(field.getField(spy::util::Point(1, 4)).getFieldState(), spy::scenario::FieldStateEnum::BAR_SEAT);
-    EXPECT_EQ(field.getField(spy::util::Point(2, 4)).getFieldState(), spy::scenario::FieldStateEnum::FREE);
-    EXPECT_EQ(field.getField(spy::util::Point(3, 4)).getFieldState(), spy::scenario::FieldStateEnum::WALL);
-    EXPECT_EQ(field.getField(spy::util::Point(4, 4)).getFieldState(), spy::scenario::FieldStateEnum::FREE);
-    EXPECT_EQ(field.getField(spy::util::Point(5, 4)).getFieldState(), spy::scenario::FieldStateEnum::FREE);
-    EXPECT_EQ(field.getField(spy::util::Point(6, 4)).getFieldState(), spy::scenario::FieldStateEnum::WALL);
+    EXPECT_EQ(field.getField({0, 4}).getFieldState(), spy::scenario::FieldStateEnum::WALL);
+    EXPECT_EQ(field.getField({1, 4}).getFieldState(), spy::scenario::FieldStateEnum::BAR_SEAT);
+    EXPECT_EQ(field.getField({2, 4}).getFieldState(), spy::scenario::FieldStateEnum::FREE);
+    EXPECT_EQ(field.getField({3, 4}).getFieldState(), spy::scenario::FieldStateEnum::WALL);
+    EXPECT_EQ(field.getField({4, 4}).getFieldState(), spy::scenario::FieldStateEnum::FREE);
+    EXPECT_EQ(field.getField({5, 4}).getFieldState(), spy::scenario::FieldStateEnum::FREE);
+    EXPECT_EQ(field.getField({6, 4}).getFieldState(), spy::scenario::FieldStateEnum::WALL);
 
-    EXPECT_EQ(field.getField(spy::util::Point(0, 5)).getFieldState(), spy::scenario::FieldStateEnum::WALL);
-    EXPECT_EQ(field.getField(spy::util::Point(1, 5)).getFieldState(), spy::scenario::FieldStateEnum::FREE);
-    EXPECT_EQ(field.getField(spy::util::Point(2, 5)).getFieldState(), spy::scenario::FieldStateEnum::FREE);
-    EXPECT_EQ(field.getField(spy::util::Point(3, 5)).getFieldState(), spy::scenario::FieldStateEnum::FREE);
-    EXPECT_EQ(field.getField(spy::util::Point(4, 5)).getFieldState(), spy::scenario::FieldStateEnum::FREE);
-    EXPECT_EQ(field.getField(spy::util::Point(5, 5)).getFieldState(), spy::scenario::FieldStateEnum::SAFE);
-    EXPECT_EQ(field.getField(spy::util::Point(6, 5)).getFieldState(), spy::scenario::FieldStateEnum::WALL);
+    EXPECT_EQ(field.getField({0, 5}).getFieldState(), spy::scenario::FieldStateEnum::WALL);
+    EXPECT_EQ(field.getField({1, 5}).getFieldState(), spy::scenario::FieldStateEnum::FREE);
+    EXPECT_EQ(field.getField({2, 5}).getFieldState(), spy::scenario::FieldStateEnum::FREE);
+    EXPECT_EQ(field.getField({3, 5}).getFieldState(), spy::scenario::FieldStateEnum::FREE);
+    EXPECT_EQ(field.getField({4, 5}).getFieldState(), spy::scenario::FieldStateEnum::FREE);
+    EXPECT_EQ(field.getField({5, 5}).getFieldState(), spy::scenario::FieldStateEnum::SAFE);
+    EXPECT_EQ(field.getField({6, 5}).getFieldState(), spy::scenario::FieldStateEnum::WALL);
 
-    EXPECT_EQ(field.getField(spy::util::Point(0, 6)).getFieldState(), spy::scenario::FieldStateEnum::WALL);
-    EXPECT_EQ(field.getField(spy::util::Point(1, 6)).getFieldState(), spy::scenario::FieldStateEnum::WALL);
-    EXPECT_EQ(field.getField(spy::util::Point(2, 6)).getFieldState(), spy::scenario::FieldStateEnum::WALL);
-    EXPECT_EQ(field.getField(spy::util::Point(3, 6)).getFieldState(), spy::scenario::FieldStateEnum::WALL);
-    EXPECT_EQ(field.getField(spy::util::Point(4, 6)).getFieldState(), spy::scenario::FieldStateEnum::WALL);
-    EXPECT_EQ(field.getField(spy::util::Point(5, 6)).getFieldState(), spy::scenario::FieldStateEnum::WALL);
-    EXPECT_EQ(field.getField(spy::util::Point(6, 6)).getFieldState(), spy::scenario::FieldStateEnum::WALL);
+    EXPECT_EQ(field.getField({0, 6}).getFieldState(), spy::scenario::FieldStateEnum::WALL);
+    EXPECT_EQ(field.getField({1, 6}).getFieldState(), spy::scenario::FieldStateEnum::WALL);
+    EXPECT_EQ(field.getField({2, 6}).getFieldState(), spy::scenario::FieldStateEnum::WALL);
+    EXPECT_EQ(field.getField({3, 6}).getFieldState(), spy::scenario::FieldStateEnum::WALL);
+    EXPECT_EQ(field.getField({4, 6}).getFieldState(), spy::scenario::FieldStateEnum::WALL);
+    EXPECT_EQ(field.getField({5, 6}).getFieldState(), spy::scenario::FieldStateEnum::WALL);
+    EXPECT_EQ(field.getField({6, 6}).getFieldState(), spy::scenario::FieldStateEnum::WALL);
 }
 
 TEST(Scenario, FieldMapSetters) {
@@ -169,12 +169,12 @@ TEST(Scenario, FieldMapSetters) {
 
     spy::scenario::Field f(spy::scenario::FieldStateEnum::FREE);
     EXPECT_NO_THROW(field.setField(0, 0, f));
-    EXPECT_EQ(field.getField(spy::util::Point(0, 0)).getFieldState(), spy::scenario::FieldStateEnum::FREE);
+    EXPECT_EQ(field.getField({0, 0}).getFieldState(), spy::scenario::FieldStateEnum::FREE);
 
-    EXPECT_NO_THROW(field.setField(spy::util::Point(0, 0), f));
-    EXPECT_EQ(field.getField(spy::util::Point(0, 0)).getFieldState(), spy::scenario::FieldStateEnum::FREE);
+    EXPECT_NO_THROW(field.setField({0, 0}, f));
+    EXPECT_EQ(field.getField({0, 0}).getFieldState(), spy::scenario::FieldStateEnum::FREE);
 
-    EXPECT_ANY_THROW(field.setField(spy::util::Point(-1, 0), f));
+    EXPECT_ANY_THROW(field.setField({-1, 0}, f));
 }
 
 TEST(Scenario, FieldInsideTest) {
@@ -193,17 +193,17 @@ TEST(Scenario, FieldInsideTest) {
 
     spy::scenario::FieldMap field(decodedScenario);
 
-    for (unsigned int y = 0; y < 7; y++) {
-        for (unsigned int x = 0; x < 7; x++) {
-            EXPECT_TRUE(field.isInside(spy::util::Point(x, y)));
+    for (int y = 0; y < 7; y++) {
+        for (int x = 0; x < 7; x++) {
+            EXPECT_TRUE(field.isInside({x, y}));
         }
     }
 
-    for (unsigned int i = 0; i < 7; i++) {
-        EXPECT_FALSE(field.isInside(spy::util::Point(-1, i)));
-        EXPECT_FALSE(field.isInside(spy::util::Point(7, i)));
-        EXPECT_FALSE(field.isInside(spy::util::Point(i, -1)));
-        EXPECT_FALSE(field.isInside(spy::util::Point(i, 7)));
+    for (int i = 0; i < 7; i++) {
+        EXPECT_FALSE(field.isInside({-1, i}));
+        EXPECT_FALSE(field.isInside({7, i}));
+        EXPECT_FALSE(field.isInside({i, -1}));
+        EXPECT_FALSE(field.isInside({i, 7}));
     }
 }
 
@@ -248,8 +248,8 @@ TEST(Scenario, ScenarioSetters) {
     EXPECT_NO_THROW(decodedScenario.setField(0, 0, spy::scenario::FieldStateEnum::FREE));
     EXPECT_EQ(decodedScenario.getField(0, 0), spy::scenario::FieldStateEnum::FREE);
 
-    EXPECT_NO_THROW(decodedScenario.setField(spy::util::Point(0, 1), spy::scenario::FieldStateEnum::FREE));
-    EXPECT_EQ(decodedScenario.getField(spy::util::Point(0, 1)), spy::scenario::FieldStateEnum::FREE);
+    EXPECT_NO_THROW(decodedScenario.setField({0, 1}, spy::scenario::FieldStateEnum::FREE));
+    EXPECT_EQ(decodedScenario.getField({0, 1}), spy::scenario::FieldStateEnum::FREE);
 
     EXPECT_ANY_THROW(decodedScenario.setField(1, 0, spy::scenario::FieldStateEnum::FREE));
 }

--- a/test/util/pointTest.cpp
+++ b/test/util/pointTest.cpp
@@ -8,14 +8,14 @@
 
 TEST(Point, Point) {
     spy::util::Point p1 = {};
-    EXPECT_EQ(p1.getX(), 0);
-    EXPECT_EQ(p1.getY(), 0);
+    EXPECT_EQ(p1.x, 0);
+    EXPECT_EQ(p1.y, 0);
     EXPECT_TRUE(p1 == p1);
     EXPECT_FALSE(p1 != p1);
 
     spy::util::Point p2 = {3, 5};
-    EXPECT_EQ(p2.getX(), 3);
-    EXPECT_EQ(p2.getY(), 5);
+    EXPECT_EQ(p2.x, 3);
+    EXPECT_EQ(p2.y, 5);
     EXPECT_TRUE(p2 == p2);
     EXPECT_FALSE(p2 != p2);
     EXPECT_FALSE(p1 == p2);
@@ -25,35 +25,35 @@ TEST(Point, Point) {
 
     spy::util::Point p3 = {5, 3};
     spy::util::Point p4 = p2 + p3;
-    EXPECT_EQ(p4.getX(), 8);
-    EXPECT_EQ(p4.getY(), 8);
+    EXPECT_EQ(p4.x, 8);
+    EXPECT_EQ(p4.y, 8);
 
     spy::util::Point p5 = p4 - p3;
-    EXPECT_EQ(p5.getX(), p2.getX());
-    EXPECT_EQ(p5.getY(), p2.getY());
+    EXPECT_EQ(p5.x, p2.x);
+    EXPECT_EQ(p5.y, p2.y);
 
     p2 += {2, 3};
-    EXPECT_EQ(p2.getX(), 5);
-    EXPECT_EQ(p2.getY(), 8);
+    EXPECT_EQ(p2.x, 5);
+    EXPECT_EQ(p2.y, 8);
     EXPECT_FALSE(p1 == p2);
     EXPECT_FALSE(p2 == p1);
     EXPECT_TRUE(p1 != p2);
     EXPECT_TRUE(p2 != p1);
 
-    p1.setLocation(5, 8);
-    EXPECT_EQ(p1.getX(), 5);
-    EXPECT_EQ(p1.getY(), 8);
+    p1 = {5, 8};
+    EXPECT_EQ(p1.x, 5);
+    EXPECT_EQ(p1.y, 8);
     EXPECT_TRUE(p1 == p2);
     EXPECT_TRUE(p2 == p1);
     EXPECT_FALSE(p1 != p2);
     EXPECT_FALSE(p2 != p1);
 
     p2 -= {5, 8};
-    EXPECT_EQ(p2.getX(), 0);
-    EXPECT_EQ(p2.getY(), 0);
+    EXPECT_EQ(p2.x, 0);
+    EXPECT_EQ(p2.y, 0);
     p2 += {-1, 0};
-    EXPECT_EQ(p2.getX(), -1);
-    EXPECT_EQ(p2.getY(), 0);
+    EXPECT_EQ(p2.x, -1);
+    EXPECT_EQ(p2.y, 0);
 
     std::stringstream stream;
     stream << p1;
@@ -70,7 +70,7 @@ TEST(Point, json_decode) {
 }
 
 TEST(Point, json_encode) {
-    spy::util::Point point(8, 13);
+    spy::util::Point point{8, 13};
 
     nlohmann::json pointJson = point;
 


### PR DESCRIPTION
Refactoring der point klasse, mit dem Ziel schöneren code zu haben (z.B. in #66).

Konstruktor wurde auch entfernt, somit ist die klasse ein aggregate und kann aggregate initialisiert werden (`util::Point p = {1, 2};`, `util::Point p2{2, 3};`)

Off-Topic (sorry): Fixt die coverage für die tests (sollte ja immer 100% sein...), die ist in 11b19552e608eb4f6f29207c1f40af5bb23a36c6 kaputt gegangen