### PR TITLE
fixing build with LibCommon as Submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ add_subdirectory(src)
 
 option(LIBCOMMON_TESTS "Build the tests" ON)
 if (LIBCOMMON_TESTS)
-    if (NOT TARGET gtest)
+    if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
         # Download and unpack googletest at configure time
         configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
         execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .


### PR DESCRIPTION
gtest war immer target
stattdessen wird hier darauf gecheckt, ob das ein Sub-Cmake-File, also ein Cmake-File von einem Submodule ist
löst [LibClient#15](https://github.com/SoPra-Team-17/LibClient/issues/15)