### PR TITLE
Rework of the set for characters

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SOURCE
         datatypes/character/Character.cpp
         datatypes/character/CharacterInformation.cpp
         datatypes/character/CharacterDescription.cpp
+        datatypes/character/CharacterSet.cpp
         datatypes/matchconfig/MatchConfig.cpp
         datatypes/scenario/Scenario.cpp
         datatypes/scenario/Scenario.cpp

--- a/src/datatypes/character/Character.cpp
+++ b/src/datatypes/character/Character.cpp
@@ -122,8 +122,4 @@ namespace spy::character {
                std::tie(rhs.characterId, rhs.name, rhs.coordinates, rhs.movePoints, rhs.actionPoints, rhs.healthPoints,
                         rhs.intelligencePoints, rhs.chips, rhs.properties, rhs.gadgets);
     }
-
-    bool Character::strong_order_compare::operator()(const Character &lhs, const Character &rhs) const {
-        return lhs.characterId < rhs.characterId;
-    }
 }  // namespace spy::character

--- a/src/datatypes/character/Character.hpp
+++ b/src/datatypes/character/Character.hpp
@@ -77,17 +77,6 @@ namespace spy::character {
 
             bool operator==(const Character &rhs) const;
 
-            /**
-             * Implements an ordering for Character, while not stating an actual ordering and implying equality by UUID
-             * through operator<.
-             * TODO(C++20): replace with std::strong_ordering strong_order(Character lhs, Character rhs)
-             */
-            struct strong_order_compare {
-                bool operator()(const Character &lhs, const Character &rhs) const;
-            };
-
-            using Set = std::set<character::Character, Character::strong_order_compare>;
-
         private:
             spy::util::UUID characterId;
             std::string name;

--- a/src/datatypes/character/CharacterSet.cpp
+++ b/src/datatypes/character/CharacterSet.cpp
@@ -8,7 +8,11 @@
 #include "CharacterSet.hpp"
 
 namespace spy::character {
-    CharacterSet::CharacterSet(std::initializer_list<Character> list) : characters(list) {}
+    CharacterSet::CharacterSet(std::initializer_list<Character> list) {
+        for (const auto &c:list) {
+            insert(c);
+        }
+    }
 
     CharacterSet::iterator CharacterSet::begin() noexcept {
         return characters.begin();
@@ -34,8 +38,8 @@ namespace spy::character {
         return characters.size();
     }
 
-    std::pair<CharacterSet::iterator, bool> CharacterSet::emplace(const util::UUID  &characterId,
-                                                                   const std::string &name) {
+    std::pair<CharacterSet::iterator, bool> CharacterSet::emplace(const util::UUID &characterId,
+                                                                  const std::string &name) {
         if (containsUUID(characterId)) {
             return std::pair<std::vector<Character>::iterator, bool>(end(), false);
         } else {

--- a/src/datatypes/character/CharacterSet.cpp
+++ b/src/datatypes/character/CharacterSet.cpp
@@ -41,28 +41,28 @@ namespace spy::character {
     std::pair<CharacterSet::iterator, bool> CharacterSet::emplace(const util::UUID &characterId,
                                                                   const std::string &name) {
         if (containsUUID(characterId)) {
-            return std::pair<std::vector<Character>::iterator, bool>(end(), false);
+            return {end(), false};
         } else {
             characters.emplace_back(characterId, name);
-            return std::pair<std::vector<Character>::iterator, bool>(end() - 1, true);
+            return {end() - 1, true};
         }
     }
 
     std::pair<CharacterSet::iterator, bool> CharacterSet::insert(Character &&c) {
         if (containsUUID(c.getCharacterId())) {
-            return std::pair<std::vector<Character>::iterator, bool>(end(), false);
+            return {end(), false};
         } else {
             characters.push_back(std::move(c));
-            return std::pair<std::vector<Character>::iterator, bool>(end() - 1, true);
+            return {end() - 1, true};
         }
     }
 
     std::pair<CharacterSet::iterator, bool> CharacterSet::insert(const Character &c) {
         if (containsUUID(c.getCharacterId())) {
-            return std::pair<std::vector<Character>::iterator, bool>(end(), false);
+            return {end(), false};
         } else {
             characters.push_back(c);
-            return std::pair<std::vector<Character>::iterator, bool>(end() - 1, true);
+            return {end() - 1, true};
         }
     }
 

--- a/src/datatypes/character/CharacterSet.cpp
+++ b/src/datatypes/character/CharacterSet.cpp
@@ -75,9 +75,11 @@ namespace spy::character {
     }
 
     CharacterSet::iterator CharacterSet::getByUUID(const util::UUID &uuid) {
-        auto character = findByUUID(uuid);
+        auto character = std::find_if(characters.begin(), characters.end(), [&uuid](const character::Character &c) {
+            return c.getCharacterId() == uuid;
+        });
 
-        return characters.erase(character, character);                  // converts from const_iterator to iterator
+        return character;
     }
 
     CharacterSet::const_iterator CharacterSet::findByLocation(const util::Point &p) const {

--- a/src/datatypes/character/CharacterSet.cpp
+++ b/src/datatypes/character/CharacterSet.cpp
@@ -82,21 +82,6 @@ namespace spy::character {
         return character;
     }
 
-    CharacterSet::const_iterator CharacterSet::findByLocation(const util::Point &p) const {
-        auto character = std::find_if(characters.begin(), characters.end(), [&p](const character::Character &c) {
-            return c.getCoordinates() == p;
-        });
-
-        return character;
-    }
-
-    CharacterSet::iterator CharacterSet::getByLocation(const util::Point &p) {
-        auto character = findByLocation(p);
-
-        return characters.erase(character, character);                  // converts from const_iterator to iterator
-    }
-
-
     bool CharacterSet::operator==(const CharacterSet &rhs) const {
         return characters == rhs.characters;
     }

--- a/src/datatypes/character/CharacterSet.cpp
+++ b/src/datatypes/character/CharacterSet.cpp
@@ -1,0 +1,103 @@
+/**
+ * @file   CharacterSet.cpp
+ * @author Dominik Authaler
+ * @date   25.04.2020 (creation)
+ * @brief  Definition of a specialized set for characters.
+ */
+
+#include "CharacterSet.hpp"
+
+namespace spy::character {
+    CharacterSet::CharacterSet(std::initializer_list<Character> list) : characters(list) {}
+
+    CharacterSet::iterator CharacterSet::begin() noexcept {
+        return characters.begin();
+    }
+
+    CharacterSet::const_iterator CharacterSet::begin() const noexcept {
+        return characters.begin();
+    }
+
+    CharacterSet::iterator CharacterSet::end() noexcept {
+        return characters.end();
+    }
+
+    CharacterSet::const_iterator CharacterSet::end() const noexcept {
+        return characters.end();
+    }
+
+    bool CharacterSet::empty() const noexcept {
+        return characters.empty();
+    }
+
+    size_t CharacterSet::size() const noexcept {
+        return characters.size();
+    }
+
+    std::pair<CharacterSet::iterator, bool> CharacterSet::emplace(const util::UUID  &characterId,
+                                                                   const std::string &name) {
+        Character c(characterId, name);
+        return insert(c);
+    }
+
+    std::pair<CharacterSet::iterator, bool> CharacterSet::insert(Character &&c) {
+        for (const auto &character : characters) {
+            if (Character::strong_order_compare()(character, c) && Character::strong_order_compare()(c, character)) {
+                return std::pair<std::vector<Character>::iterator, bool>(end(), false);
+            }
+        }
+        characters.push_back(std::move(c));
+        return std::pair<std::vector<Character>::iterator, bool>(end() - 1, true);
+    }
+
+    std::pair<CharacterSet::iterator, bool> CharacterSet::insert(const Character &c) {
+        for (const auto &character : characters) {
+            if (Character::strong_order_compare()(character, c) && Character::strong_order_compare()(c, character)) {
+                return std::pair<CharacterSet::iterator, bool>(end(), false);
+            }
+        }
+        characters.push_back(c);
+        return std::pair<CharacterSet::iterator, bool>(end() - 1, true);
+    }
+
+    CharacterSet::const_iterator CharacterSet::findByUUID(const util::UUID &uuid) const {
+        auto character = std::find_if(characters.begin(), characters.end(), [&uuid](const character::Character &c) {
+            return c.getCharacterId() == uuid;
+        });
+
+        return character;
+    }
+
+    CharacterSet::iterator CharacterSet::getByUUID(const util::UUID &uuid) {
+        auto character = findByUUID(uuid);
+
+        return characters.erase(character, character);
+    }
+
+    CharacterSet::const_iterator CharacterSet::findByLocation(const util::Point &p) const {
+        auto character = std::find_if(characters.begin(), characters.end(), [&p](const character::Character &c) {
+            return c.getCoordinates() == p;
+        });
+
+        return character;
+    }
+
+    CharacterSet::iterator CharacterSet::getByLocation(const util::Point &p) {
+        auto character = findByLocation(p);
+
+        return characters.erase(character, character);
+    }
+
+
+    bool CharacterSet::operator==(const CharacterSet &rhs) const {
+        return characters == rhs.characters;
+    }
+
+    void to_json(nlohmann::json &j, const CharacterSet &c) {
+        j = c.characters;
+    }
+
+    void from_json(const nlohmann::json &j, CharacterSet &c) {
+        j.get_to(c.characters);
+    }
+}

--- a/src/datatypes/character/CharacterSet.hpp
+++ b/src/datatypes/character/CharacterSet.hpp
@@ -17,11 +17,12 @@ namespace spy::character {
      * @note
      */
     class CharacterSet {
-        using iterator = std::vector<Character>::iterator;
-        using const_iterator = std::vector<Character>::const_iterator;
+            using iterator = std::vector<Character>::iterator;
+            using const_iterator = std::vector<Character>::const_iterator;
 
         public:
             CharacterSet() = default;
+
             explicit CharacterSet(std::initializer_list<Character> list);
 
             /**
@@ -64,16 +65,14 @@ namespace spy::character {
              */
             [[nodiscard]] size_t size() const noexcept;
 
-            std::pair<iterator, bool> emplace(const util::UUID &characterId,
-                                              const std::string &name);
+            std::pair<iterator, bool> emplace(const util::UUID &characterId, const std::string &name);
 
             [[nodiscard]] const_iterator findByUUID(const util::UUID &uuid) const;
+
             iterator getByUUID(const util::UUID &uuid);
 
-            [[nodiscard]] const_iterator findByLocation(const util::Point &p) const;
-            iterator getByLocation(const util::Point &p);
-
             std::pair<iterator, bool> insert(Character &&c);
+
             std::pair<iterator, bool> insert(const Character &c);
 
             bool operator==(const CharacterSet &rhs) const;

--- a/src/datatypes/character/CharacterSet.hpp
+++ b/src/datatypes/character/CharacterSet.hpp
@@ -14,7 +14,8 @@ namespace spy::character {
     /**
      * @brief   Realizes a specialized set for characters.
      * @details Characters are sorted solely by their UUID.
-     * @note
+     * @note    Because the UUID of a character isn't modifiable, it's perfectly fine to enable the use
+     *          of iterators instead of the const_iterators a normal set would return.
      */
     class CharacterSet {
             using iterator = std::vector<Character>::iterator;
@@ -65,15 +66,46 @@ namespace spy::character {
              */
             [[nodiscard]] size_t size() const noexcept;
 
+            /**
+             * Inserts a new in-place constructed character into the set if the uuid isn't already contained.
+             * @param  characterId UUID of the character.
+             * @param  name        Name of the character.
+             * @return Iterator to the end of the set and false if the uuid was already in the set, otherwise
+             *         an iterator to the added character and true.
+             */
             std::pair<iterator, bool> emplace(const util::UUID &characterId, const std::string &name);
 
-            [[nodiscard]] const_iterator findByUUID(const util::UUID &uuid) const;
-
-            iterator getByUUID(const util::UUID &uuid);
-
+            /**
+             * Inserts a new character into the set if the uuid isn't already contained.
+             * @param  c Character to insert.
+             * @return Iterator to the end of the set and false if the uuid was already in the set, otherwise
+             *         an iterator to the added character and true.
+             */
             std::pair<iterator, bool> insert(Character &&c);
 
+            /**
+             * Inserts a new character into the set if the uuid isn't already contained.
+             * @param  c Character to insert.
+             * @return Iterator to the end of the set and false if the uuid was already in the set, otherwise
+             *         an iterator to the added character and true.
+             */
             std::pair<iterator, bool> insert(const Character &c);
+
+            /**
+             * Searches the set for a character with the given uuid.
+             * @param  uuid UUID to search for.
+             * @return Const iterator to the found character if one with the specified uuid exits, otherwise a
+             *         const iterator to the end of the set.
+             */
+            [[nodiscard]] const_iterator findByUUID(const util::UUID &uuid) const;
+
+            /**
+             * Searches the set for a character with the given uuid.
+             * @param  uuid UUID to search for.
+             * @return Iterator to the found character if one with the specified uuid exits, otherwise an
+             *         iterator to the end of the set.
+             */
+            iterator getByUUID(const util::UUID &uuid);
 
             bool operator==(const CharacterSet &rhs) const;
 

--- a/src/datatypes/character/CharacterSet.hpp
+++ b/src/datatypes/character/CharacterSet.hpp
@@ -21,8 +21,8 @@ namespace spy::character {
         using const_iterator = std::vector<Character>::const_iterator;
 
         public:
-            explicit CharacterSet() = default;
-            CharacterSet(std::initializer_list<Character> list);
+            CharacterSet() = default;
+            explicit CharacterSet(std::initializer_list<Character> list);
 
             /**
              * Returns an iterator to the beginning of the set.
@@ -32,6 +32,10 @@ namespace spy::character {
              */
             [[nodiscard]] iterator begin() noexcept;
 
+            /**
+             * Returns an iterator to the beginning of the set.
+             * @return Const iterator to the beginning of the set.
+             */
             [[nodiscard]] const_iterator begin() const noexcept;
 
             /**
@@ -41,9 +45,23 @@ namespace spy::character {
              * @return Non-const iterator to the end of the set.
              */
             [[nodiscard]] iterator end() noexcept;
+
+            /**
+             * Returns an iterator to the end of the set.
+             * @return Const iterator to the end of the set.
+             */
             [[nodiscard]] const_iterator end() const noexcept;
 
+            /**
+             * Test whether the container is empty.
+             * @return True if the container size is 0, false otherwise.
+             */
             [[nodiscard]] bool empty() const noexcept;
+
+            /**
+             * Getter for the number of elements in the container.
+             * @return The number of elements in the container.
+             */
             [[nodiscard]] size_t size() const noexcept;
 
             std::pair<iterator, bool> emplace(const util::UUID &characterId,
@@ -65,7 +83,7 @@ namespace spy::character {
             friend void from_json(const nlohmann::json &j, CharacterSet &c);
 
         private:
-            [[nodiscard]] bool isUUIDIncluded(util::UUID uuid) const;
+            [[nodiscard]] bool containsUUID(util::UUID uuid) const;
 
             std::vector<Character> characters;
     };

--- a/src/datatypes/character/CharacterSet.hpp
+++ b/src/datatypes/character/CharacterSet.hpp
@@ -23,7 +23,7 @@ namespace spy::character {
         public:
             CharacterSet() = default;
 
-            explicit CharacterSet(std::initializer_list<Character> list);
+            CharacterSet(std::initializer_list<Character> list);
 
             /**
              * Returns an iterator to the beginning of the set.

--- a/src/datatypes/character/CharacterSet.hpp
+++ b/src/datatypes/character/CharacterSet.hpp
@@ -1,0 +1,75 @@
+/**
+ * @file   CharacterSet.hpp
+ * @author Dominik Authaler
+ * @date   25.04.2020 (creation)
+ * @brief  Declaration of a specialized set for characters.
+ */
+
+#ifndef LIBCOMMON_CHARACTER_SET_HPP
+#define LIBCOMMON_CHARACTER_SET_HPP
+
+#include "character/Character.hpp"
+
+namespace spy::character {
+    /**
+     * @brief   Realizes a specialized set for characters.
+     * @details Characters are sorted solely by their UUID.
+     * @note
+     */
+    class CharacterSet {
+        using iterator = std::vector<Character>::iterator;
+        using const_iterator = std::vector<Character>::const_iterator;
+
+        public:
+            explicit CharacterSet() = default;
+            CharacterSet(std::initializer_list<Character> list);
+
+            /**
+             * Returns an iterator to the beginning of the set.
+             * @note   Because characters are sorted solely by their UUID and this is not editable, it's
+             *         possible to use a non-const iterator.
+             * @return Non-const iterator to the beginning of the set.
+             */
+            [[nodiscard]] iterator begin() noexcept;
+
+            [[nodiscard]] const_iterator begin() const noexcept;
+
+            /**
+             * Returns an iterator to the end of the set.
+             * @note   Because characters are sorted solely by their UUID and this is not editable, it's
+             *         possible to use a non-const iterator.
+             * @return Non-const iterator to the end of the set.
+             */
+            [[nodiscard]] iterator end() noexcept;
+            [[nodiscard]] const_iterator end() const noexcept;
+
+            [[nodiscard]] bool empty() const noexcept;
+            [[nodiscard]] size_t size() const noexcept;
+
+            std::pair<iterator, bool> emplace(const util::UUID &characterId,
+                                              const std::string &name);
+
+            [[nodiscard]] const_iterator findByUUID(const util::UUID &uuid) const;
+            iterator getByUUID(const util::UUID &uuid);
+
+            [[nodiscard]] const_iterator findByLocation(const util::Point &p) const;
+            iterator getByLocation(const util::Point &p);
+
+            std::pair<iterator, bool> insert(Character &&c);
+            std::pair<iterator, bool> insert(const Character &c);
+
+            bool operator==(const CharacterSet &rhs) const;
+
+            friend void to_json(nlohmann::json &j, const CharacterSet &c);
+
+            friend void from_json(const nlohmann::json &j, CharacterSet &c);
+
+        private:
+            [[nodiscard]] bool isUUIDIncluded(util::UUID uuid) const;
+
+            std::vector<Character> characters;
+    };
+}
+
+
+#endif //LIBCOMMON_CHARACTER_SET_HPP

--- a/src/datatypes/gameplay/State.cpp
+++ b/src/datatypes/gameplay/State.cpp
@@ -1,39 +1,24 @@
-//
-// Created by marco on 10.04.20.
-//
+/**
+ * @file   State.cpp
+ * @author Marco
+ * @date   10.04.2020 (creation)
+ * @brief  Entire state of the game.
+ */
 
 #include "State.hpp"
 
 #include <utility>
 
 namespace spy::gameplay {
-    void to_json(nlohmann::json &j, const State &s) {
-        j["currentRound"] = s.currentRound;
-        j["map"] = s.map;
-        j["mySafeCombinations"] = s.mySafeCombinations;
-        j["characters"] = s.characters;
-        j["catCoordinates"] = s.catCoordinates;
-        j["janitorCoordinates"] = s.janitorCoordinates;
-    }
-
-    void from_json(const nlohmann::json &j, State &s) {
-        j.at("currentRound").get_to(s.currentRound);
-        j.at("map").get_to(s.map);
-        j.at("mySafeCombinations").get_to(s.mySafeCombinations);
-        j.at("characters").get_to(s.characters);
-
-        auto catCoordinatesJson = j.find("catCoordinates");
-        if (catCoordinatesJson != j.end()) {
-            // Use setter instead of get_to to properly handle coordinates outside the map
-            s.setCatCoordinates(catCoordinatesJson->get<decltype(s.catCoordinates)>());
-        }
-
-        auto janitorCoordinatesJson = j.find("janitorCoordinates");
-        if (janitorCoordinatesJson != j.end()) {
-            // Use setter instead of get_to to properly handle coordinates outside the map
-            s.setJanitorCoordinates(janitorCoordinatesJson->get<decltype(s.janitorCoordinates)>());
-        }
-    }
+    State::State(unsigned int currentRound, scenario::FieldMap map, std::set<int> mySafeCombinations,
+                 character::CharacterSet characters, const std::optional<util::Point> &catCoordinates,
+                 const std::optional<util::Point> &janitorCoordinates) :
+            currentRound(currentRound),
+            map(std::move(map)),
+            mySafeCombinations(std::move(mySafeCombinations)),
+            characters(std::move(characters)),
+            catCoordinates(catCoordinates),
+            janitorCoordinates(janitorCoordinates) {}
 
 
     unsigned int State::getCurrentRound() const {
@@ -48,7 +33,7 @@ namespace spy::gameplay {
         return mySafeCombinations;
     }
 
-    const character::Character::Set &State::getCharacters() const {
+    const character::CharacterSet &State::getCharacters() const {
         return characters;
     }
 
@@ -82,14 +67,33 @@ namespace spy::gameplay {
                         rhs.janitorCoordinates);
     }
 
-    State::State(unsigned int currentRound, scenario::FieldMap map, std::set<int> mySafeCombinations,
-                 character::Character::Set characters, const std::optional<util::Point> &catCoordinates,
-                 const std::optional<util::Point> &janitorCoordinates) :
-            currentRound(currentRound),
-            map(std::move(map)),
-            mySafeCombinations(std::move(mySafeCombinations)),
-            characters(std::move(characters)),
-            catCoordinates(catCoordinates),
-            janitorCoordinates(janitorCoordinates) {}
+    void to_json(nlohmann::json &j, const State &s) {
+        j["currentRound"] = s.currentRound;
+        j["map"] = s.map;
+        j["mySafeCombinations"] = s.mySafeCombinations;
+        j["characters"] = s.characters;
+        j["catCoordinates"] = s.catCoordinates;
+        j["janitorCoordinates"] = s.janitorCoordinates;
+    }
+
+    void from_json(const nlohmann::json &j, State &s) {
+        j.at("currentRound").get_to(s.currentRound);
+        j.at("map").get_to(s.map);
+        j.at("mySafeCombinations").get_to(s.mySafeCombinations);
+        j.at("characters").get_to(s.characters);
+
+        auto catCoordinatesJson = j.find("catCoordinates");
+        if (catCoordinatesJson != j.end()) {
+            // Use setter instead of get_to to properly handle coordinates outside the map
+            s.setCatCoordinates(catCoordinatesJson->get<decltype(s.catCoordinates)>());
+        }
+
+        auto janitorCoordinatesJson = j.find("janitorCoordinates");
+        if (janitorCoordinatesJson != j.end()) {
+            // Use setter instead of get_to to properly handle coordinates outside the map
+            s.setJanitorCoordinates(janitorCoordinatesJson->get<decltype(s.janitorCoordinates)>());
+        }
+    }
+
 
 }

--- a/src/datatypes/gameplay/State.hpp
+++ b/src/datatypes/gameplay/State.hpp
@@ -1,16 +1,18 @@
 /**
+ * @file   State.hpp
  * @author Jonas
- * @brief Entire state of the game
+ * @brief  Entire state of the game.
  */
 
 #ifndef LIBCOMMON_STATE_HPP
 #define LIBCOMMON_STATE_HPP
 
-#include <nlohmann/json.hpp>
-#include <util/Point.hpp>
 #include <set>
-#include <datatypes/character/Character.hpp>
-#include <datatypes/scenario/FieldMap.hpp>
+#include <nlohmann/json.hpp>
+#include "util/Point.hpp"
+#include "datatypes/character/Character.hpp"
+#include "datatypes/character/CharacterSet.hpp"
+#include "datatypes/scenario/FieldMap.hpp"
 
 namespace spy::gameplay {
     class State {
@@ -19,7 +21,7 @@ namespace spy::gameplay {
             State() = default;
 
             State(unsigned int currentRound, scenario::FieldMap map, std::set<int> mySafeCombinations,
-                  character::Character::Set characters, const std::optional<util::Point> &catCoordinates,
+                  character::CharacterSet characters, const std::optional<util::Point> &catCoordinates,
                   const std::optional<util::Point> &janitorCoordinates);
 
             [[nodiscard]] unsigned int getCurrentRound() const;
@@ -28,22 +30,22 @@ namespace spy::gameplay {
 
             [[nodiscard]] const std::set<int> &getMySafeCombinations() const;
 
-            [[nodiscard]] const character::Character::Set &getCharacters() const;
+            [[nodiscard]] const character::CharacterSet &getCharacters() const;
 
             [[nodiscard]] const std::optional<util::Point> &getCatCoordinates() const;
 
             [[nodiscard]] const std::optional<util::Point> &getJanitorCoordinates() const;
 
             /**
-              * Sets the cat coordinates
-              * @brief Standard specifies that absence of cat can be indicated by coordinates outside the map, so this resets
+              * @brief Sets the cat coordinates.
+              * @details Standard specifies that absence of cat can be indicated by coordinates outside the map, so this resets
               * the catCoordinates optional if the coordinates are outside the map.
               */
             void setCatCoordinates(const std::optional<util::Point> &catCoordinates);
 
             /**
-             * Sets the janitor coordinates
-             * @brief Standard specifies that absence of janitor can be indicated by coordinates outside the map, so this resets
+             * @brief Sets the janitor coordinates.
+             * @details Standard specifies that absence of janitor can be indicated by coordinates outside the map, so this resets
              * the janitorCoordinates optional if the coordinates are outside the map.
              */
             void setJanitorCoordinates(const std::optional<util::Point> &janitorCoordinates);
@@ -58,7 +60,7 @@ namespace spy::gameplay {
             unsigned int currentRound = 0;
             scenario::FieldMap map;
             std::set<int> mySafeCombinations;
-            character::Character::Set characters{};
+            character::CharacterSet characters{};
             std::optional<util::Point> catCoordinates;
             std::optional<util::Point> janitorCoordinates;
     };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES
         datatypes/gadgetTest.cpp
         datatypes/jsonEncodingTest.cpp
         datatypes/jsonDecodingTest.cpp
+        datatypes/characterSetTest.cpp
         datatypes/characterTest.cpp
         datatypes/matchConfigTest.cpp
         datatypes/scenarioTest.cpp

--- a/test/datatypes/characterSetTest.cpp
+++ b/test/datatypes/characterSetTest.cpp
@@ -1,0 +1,93 @@
+//
+// Created by jonas on 26.04.20.
+//
+
+#include <gtest/gtest.h>
+#include <datatypes/character/CharacterSet.hpp>
+
+class CharacterSet : public ::testing::Test {
+    protected:
+        spy::character::CharacterSet set;
+        spy::character::Character c1 = {spy::util::UUID::generate(), "Hans Wurst"};
+        spy::character::Character c1_copy = {c1.getCharacterId(), "Not Hans Wurst"};
+        spy::character::Character c2 = {spy::util::UUID::generate(), "James Bond"};
+};
+
+TEST_F(CharacterSet, construct_valid) {
+    auto characterSet = spy::character::CharacterSet{c1, c2};
+    EXPECT_EQ(characterSet.size(), 2);
+}
+
+TEST_F(CharacterSet, construct_invalid) {
+    auto characterSet = spy::character::CharacterSet{c1, c1_copy};
+    EXPECT_EQ(characterSet.size(), 1);
+    // Expect the first element in initializer list to be used, not the second (with identical UUID)
+    EXPECT_EQ(characterSet.findByUUID(c1.getCharacterId())->getName(), c1.getName());
+}
+
+TEST_F(CharacterSet, insert_valid) {
+    auto result = set.insert(c1);
+    EXPECT_TRUE(result.second);
+
+    result = set.insert(c2);
+    EXPECT_TRUE(result.second);
+    EXPECT_EQ(set.size(), 2);
+}
+
+TEST_F(CharacterSet, insert_valid_move) {
+    auto result = set.insert(std::move(c1));
+    EXPECT_TRUE(result.second);
+
+    result = set.insert(std::move(c2));
+    EXPECT_TRUE(result.second);
+    EXPECT_EQ(set.size(), 2);
+}
+
+TEST_F(CharacterSet, emplace_valid_move) {
+    auto result = set.emplace(c1.getCharacterId(), c1.getName());
+    EXPECT_TRUE(result.second);
+
+    result = set.emplace(c2.getCharacterId(), c2.getName());
+    EXPECT_TRUE(result.second);
+    EXPECT_EQ(set.size(), 2);
+}
+
+TEST_F(CharacterSet, insert_same) {
+    set.insert(c1);
+
+    auto result = set.insert(c1);
+    EXPECT_FALSE(result.second);
+    EXPECT_EQ(set.size(), 1);
+}
+
+TEST_F(CharacterSet, insert_sameUUID) {
+    set.insert(c1);
+
+    auto result = set.insert(c1_copy);
+    EXPECT_FALSE(result.second);
+    EXPECT_EQ(set.size(), 1);
+}
+
+TEST_F(CharacterSet, insert_sameUUID_move) {
+    set.insert(std::move(c1));
+
+    auto result = set.insert(std::move(c1_copy));
+    EXPECT_FALSE(result.second);
+    EXPECT_EQ(set.size(), 1);
+}
+
+TEST_F(CharacterSet, emplace_sameUUID) {
+    set.emplace(c1.getCharacterId(), c1.getName());
+
+    auto result = set.emplace(c1_copy.getCharacterId(), c1_copy.getName());
+    EXPECT_FALSE(result.second);
+    EXPECT_EQ(set.size(), 1);
+}
+
+TEST_F(CharacterSet, get_uuid_modify) {
+    set.insert(c1);
+
+    auto c = set.getByUUID(c1.getCharacterId());
+    c->setCoordinates({1, 7});
+    EXPECT_EQ(set.findByUUID(c1.getCharacterId())->getCoordinates(), (spy::util::Point{1, 7}));
+}

--- a/test/datatypes/characterSetTest.cpp
+++ b/test/datatypes/characterSetTest.cpp
@@ -91,3 +91,29 @@ TEST_F(CharacterSet, get_uuid_modify) {
     c->setCoordinates({1, 7});
     EXPECT_EQ(set.findByUUID(c1.getCharacterId())->getCoordinates(), (spy::util::Point{1, 7}));
 }
+
+TEST_F(CharacterSet, iterate_modify) {
+    set.insert(c1);
+    set.insert(c2);
+
+    for (auto &c:set) {
+        c.setChips(1'000'000);
+    }
+
+    EXPECT_EQ(set.findByUUID(c1.getCharacterId())->getChips(), 1'000'000);
+    EXPECT_EQ(set.findByUUID(c2.getCharacterId())->getChips(), 1'000'000);
+}
+
+TEST_F(CharacterSet, iterate_const) {
+    set.insert(c1);
+    set.insert(c2);
+
+    const auto constset = set;
+
+    int i = 0;
+    spy::character::CharacterSet s;
+    for (const auto &c:constset) {
+        s.insert(c);
+    }
+    EXPECT_EQ(set, s);
+}

--- a/test/datatypes/characterSetTest.cpp
+++ b/test/datatypes/characterSetTest.cpp
@@ -117,3 +117,11 @@ TEST_F(CharacterSet, iterate_const) {
     }
     EXPECT_EQ(set, s);
 }
+
+TEST_F(CharacterSet, empty_set) {
+    EXPECT_TRUE(set.empty());
+
+    set.insert(c1);
+
+    EXPECT_FALSE(set.empty());
+}


### PR DESCRIPTION
Das aktuelle set hat die Problematik, dass std::set die Elemente als const speichert. D.h. sämtliche Operationen wie z.B. das Bewegen eines Charakters sind nur möglich, wenn man vorher explizit das const mittels einem const_cast entfernt. CharacterSet soll solche Operationen intern kapseln.