### PR TITLE
validate GameOperation und operation bug fixes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,8 @@ set(SOURCE
         datatypes/execution/ActionExecutor_Movement.cpp
         datatypes/execution/ActionExecutor_Property.cpp
         datatypes/execution/gadget/GadgetExecutor.cpp
+        datatypes/execution/ActionExecutor.cpp
+        datatypes/execution/ActionExecutor_Operation.cpp
         datatypes/matchconfig/MatchConfig.cpp
         datatypes/scenario/Scenario.cpp
         datatypes/scenario/Scenario.cpp
@@ -38,6 +40,8 @@ set(SOURCE
         datatypes/validation/PropertyValidator.cpp
         datatypes/validation/gadget/GadgetValidator.cpp
         datatypes/validation/gadget/RocketPen.cpp
+        datatypes/validation/ActionValidator.cpp
+        datatypes/validation/OperationValidator.cpp
         network/messages/EquipmentChoice.cpp
         network/messages/Error.cpp
         network/messages/GameLeave.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,7 @@ project(SopraCommon)
 find_package(nlohmann_json REQUIRED)
 
 set(SOURCE
+        datatypes/gameplay/BaseOperation.cpp
         datatypes/gadgets/Gadget.cpp
         datatypes/gadgets/WiretapWithEarplugs.cpp
         datatypes/gadgets/Cocktail.cpp

--- a/src/datatypes/execution/ActionExecutor.cpp
+++ b/src/datatypes/execution/ActionExecutor.cpp
@@ -1,0 +1,25 @@
+//
+// Created by Carolin on 29.04.2020.
+//
+
+#include "ActionExecutor.hpp"
+
+namespace spy::gameplay {
+
+    bool ActionExecutor::execute(State &s, const std::shared_ptr<Operation> &op) {
+        switch (op->getType()) {
+            case spy::gameplay::OperationEnum::MOVEMENT:
+                return ActionExecutor::execute(s, *std::dynamic_pointer_cast<gameplay::Movement>(op));
+            case gameplay::OperationEnum::GADGET_ACTION:
+                return ActionExecutor::execute(s, *std::dynamic_pointer_cast<gameplay::GadgetAction>(op));
+            case gameplay::OperationEnum::GAMBLE_ACTION:
+                return ActionExecutor::execute(s, *std::dynamic_pointer_cast<gameplay::GambleAction>(op));
+            case gameplay::OperationEnum::PROPERTY_ACTION:
+                return ActionExecutor::execute(s, *std::dynamic_pointer_cast<gameplay::PropertyAction>(op));
+            case gameplay::OperationEnum::EXFILTRATION:
+                return ActionExecutor::execute(s, *std::dynamic_pointer_cast<gameplay::Exfiltration>(op));
+            default:
+                return ActionExecutor::execute(s, *op);
+        }
+    }
+}

--- a/src/datatypes/execution/ActionExecutor.hpp
+++ b/src/datatypes/execution/ActionExecutor.hpp
@@ -20,6 +20,16 @@ namespace spy::gameplay {
         public:
             ActionExecutor() = delete;
 
+            static bool execute(State &s, const std::shared_ptr<Operation>& op);
+
+        private:
+            /**
+             * Execute Operation (CAT_ACTION, JANITOR_ACTION, RETIRE, SPY_ACTION)
+             * @param op Operation to execute, has to be valid
+             * @return true, if Operation was successful
+             */
+            static bool execute(State &s, const Operation &op);
+
             /**
              * Execute Exfiltration
              * @param op Operation to execute, has to be valid

--- a/src/datatypes/execution/ActionExecutor_Operation.cpp
+++ b/src/datatypes/execution/ActionExecutor_Operation.cpp
@@ -1,0 +1,12 @@
+//
+// Created by jonas on 28.04.20.
+//
+
+#include "ActionExecutor.hpp"
+
+namespace spy::gameplay {
+    bool ActionExecutor::execute(State &/*s*/, const Operation &/*op*/) {
+        // TODO: implement
+        return false;
+    }
+}

--- a/src/datatypes/gameplay/BaseOperation.cpp
+++ b/src/datatypes/gameplay/BaseOperation.cpp
@@ -1,0 +1,26 @@
+//
+// Created by Carolin on 29.04.2020.
+//
+
+#include "BaseOperation.hpp"
+#include <utility>
+
+namespace spy::gameplay {
+
+    BaseOperation::BaseOperation(OperationEnum type, bool successful, const util::Point &target) :
+            type{type},
+            successful{successful},
+            target{target} {}
+
+    OperationEnum BaseOperation::getType() const {
+        return type;
+    }
+
+    bool BaseOperation::isSuccessful() const {
+        return successful;
+    }
+
+    const util::Point &BaseOperation::getTarget() const {
+        return target;
+    }
+}

--- a/src/datatypes/gameplay/BaseOperation.hpp
+++ b/src/datatypes/gameplay/BaseOperation.hpp
@@ -1,0 +1,36 @@
+//
+// Created by Carolin on 29.04.2020.
+//
+
+#ifndef LIBCOMMON_BASEOPERATION_HPP
+#define LIBCOMMON_BASEOPERATION_HPP
+
+#include <util/Point.hpp>
+#include <util/UUID.hpp>
+#include "OperationEnum.hpp"
+
+namespace spy::gameplay {
+    class BaseOperation {
+        public:
+
+            BaseOperation() = default;
+
+            virtual ~BaseOperation() = default;
+
+            BaseOperation(OperationEnum type, bool successful, const util::Point &target);
+
+            [[nodiscard]] OperationEnum getType() const;
+
+            [[nodiscard]] bool isSuccessful() const;
+
+            [[nodiscard]] const util::Point &getTarget() const;
+
+        protected:
+            OperationEnum type = OperationEnum::INVALID;
+            bool successful;
+            util::Point target;
+    };
+}
+
+
+#endif //LIBCOMMON_BASEOPERATION_HPP

--- a/src/datatypes/gameplay/Operation.cpp
+++ b/src/datatypes/gameplay/Operation.cpp
@@ -8,14 +8,10 @@
 namespace spy::gameplay {
 
     Operation::Operation(OperationEnum type, bool successful, const util::Point &target) :
-            type{type},
-            successful{successful},
-            target{target} {}
+            BaseOperation(type, successful, target) {}
 
     Operation::Operation(OperationEnum type, bool successful, const util::Point &target, util::UUID characterId) :
-            type{type},
-            successful{successful},
-            target{target},
+            BaseOperation(type, successful, target),
             characterId{characterId} {}
 
     void Operation::common_to_json(nlohmann::json &j, const Operation &op) {
@@ -42,18 +38,6 @@ namespace spy::gameplay {
 
     void from_json(const nlohmann::json &j, Operation &o) {
         Operation::common_from_json(j, o);
-    }
-
-    OperationEnum Operation::getType() const {
-        return type;
-    }
-
-    bool Operation::isSuccessful() const {
-        return successful;
-    }
-
-    const util::Point &Operation::getTarget() const {
-        return target;
     }
 
     const std::optional<util::UUID> &Operation::getCharacterId() const {

--- a/src/datatypes/gameplay/Operation.hpp
+++ b/src/datatypes/gameplay/Operation.hpp
@@ -12,24 +12,17 @@
 #include <util/Point.hpp>
 #include <util/UUID.hpp>
 #include <util/OptionalSerialization.hpp>
+#include "BaseOperation.hpp"
 
 namespace spy::gameplay {
-    class Operation {
+    class Operation : public BaseOperation {
         public:
 
             Operation() = default;
 
-            virtual ~Operation() = default;
-
             Operation(OperationEnum type, bool successful, const util::Point &target);
 
             Operation(OperationEnum type, bool successful, const util::Point &target, util::UUID characterId);
-
-            [[nodiscard]] OperationEnum getType() const;
-
-            [[nodiscard]] bool isSuccessful() const;
-
-            [[nodiscard]] const util::Point &getTarget() const;
 
             [[nodiscard]] const std::optional<util::UUID> &getCharacterId() const;
 
@@ -46,9 +39,6 @@ namespace spy::gameplay {
             friend void from_json(const nlohmann::json &j, Operation &o);
 
         private:
-            OperationEnum type = OperationEnum::INVALID;
-            bool successful;
-            util::Point target;
             std::optional<util::UUID> characterId;
     };
 }

--- a/src/datatypes/gameplay/Operation.hpp
+++ b/src/datatypes/gameplay/Operation.hpp
@@ -19,6 +19,8 @@ namespace spy::gameplay {
 
             Operation() = default;
 
+            virtual ~Operation() = default;
+
             Operation(OperationEnum type, bool successful, const util::Point &target);
 
             Operation(OperationEnum type, bool successful, const util::Point &target, util::UUID characterId);

--- a/src/datatypes/gameplay/State.cpp
+++ b/src/datatypes/gameplay/State.cpp
@@ -72,7 +72,7 @@ namespace spy::gameplay {
     }
 
     bool State::performMovement(const Movement &op) {
-        if (!ActionValidator::validate(*this, std::make_shared<Operation>(op))) {
+        if (!ActionValidator::validate(*this, std::make_shared<Movement>(op))) {
             return false;
         }
 

--- a/src/datatypes/gameplay/State.cpp
+++ b/src/datatypes/gameplay/State.cpp
@@ -72,7 +72,7 @@ namespace spy::gameplay {
     }
 
     bool State::performMovement(const Movement &op) {
-        if (!ActionValidator::validate(*this, op)) {
+        if (!ActionValidator::validate(*this, std::make_shared<Operation>(op))) {
             return false;
         }
 

--- a/src/datatypes/validation/ActionValidator.cpp
+++ b/src/datatypes/validation/ActionValidator.cpp
@@ -1,0 +1,25 @@
+//
+// Created by Carolin on 29.04.2020.
+//
+
+#include "ActionValidator.hpp"
+
+namespace spy::gameplay {
+
+    bool ActionValidator::validate(const State &s, const std::shared_ptr<Operation>& op) {
+        switch (op->getType()) {
+            case spy::gameplay::OperationEnum::MOVEMENT:
+                return ActionValidator::validate(s, *std::dynamic_pointer_cast<gameplay::Movement>(op));
+            case gameplay::OperationEnum::GADGET_ACTION:
+                return ActionValidator::validate(s, *std::dynamic_pointer_cast<gameplay::GadgetAction>(op));
+            case gameplay::OperationEnum::GAMBLE_ACTION:
+                return ActionValidator::validate(s, *std::dynamic_pointer_cast<gameplay::GambleAction>(op));
+            case gameplay::OperationEnum::PROPERTY_ACTION:
+                return ActionValidator::validate(s, *std::dynamic_pointer_cast<gameplay::PropertyAction>(op));
+            case gameplay::OperationEnum::EXFILTRATION:
+                return ActionValidator::validate(s, *std::dynamic_pointer_cast<gameplay::Exfiltration>(op));
+            default:
+                return ActionValidator::validate(s, *op);
+        }
+    }
+}

--- a/src/datatypes/validation/ActionValidator.hpp
+++ b/src/datatypes/validation/ActionValidator.hpp
@@ -19,6 +19,12 @@ namespace spy::gameplay {
             // Static class
             ActionValidator() = delete;
 
+            static bool validate(const State &s, const std::shared_ptr<Operation>& op);
+
+        private:
+
+            static bool validate(const State &s, Operation op);
+
             static bool validate(const State &s, Exfiltration op);
 
             static bool validate(const State &s, GadgetAction op);

--- a/src/datatypes/validation/OperationValidator.cpp
+++ b/src/datatypes/validation/OperationValidator.cpp
@@ -1,0 +1,13 @@
+//
+// Created by Carolin on 29.04.2020.
+//
+
+#include "ActionValidator.hpp"
+
+namespace spy::gameplay {
+
+    bool ActionValidator::validate(const State &/*s*/, spy::gameplay::Operation /*op*/) {
+        // TODO implement
+        return false;
+    }
+}

--- a/src/network/messages/GameOperation.cpp
+++ b/src/network/messages/GameOperation.cpp
@@ -2,31 +2,91 @@
 // Created by jonas on 07.04.20.
 //
 
+#include <datatypes/validation/ActionValidator.hpp>
+#include <utility>
 #include "GameOperation.hpp"
 
 namespace spy::network::messages {
     GameOperation::GameOperation() : MessageContainer{MessageTypeEnum::GAME_OPERATION, {}} {}
 
-    GameOperation::GameOperation(spy::util::UUID playerId, spy::gameplay::Operation operation) :
+    GameOperation::GameOperation(spy::util::UUID playerId, std::shared_ptr<gameplay::Operation>  operation) :
             MessageContainer{MessageTypeEnum::GAME_OPERATION, playerId},
-            operation{operation} {}
+            operation{std::move(operation)} {}
 
     void to_json(nlohmann::json &j, const GameOperation &g) {
         MessageContainer::common_to_json(j, g);
-        j["operation"] = g.operation;
+        switch (g.operation->getType()) {
+            case spy::gameplay::OperationEnum::MOVEMENT:
+                j["operation"] = *std::dynamic_pointer_cast<gameplay::Movement>(g.operation);
+                break;
+            case gameplay::OperationEnum::GADGET_ACTION:
+                j["operation"] = *std::dynamic_pointer_cast<gameplay::GadgetAction>(g.operation);
+                break;
+            case gameplay::OperationEnum::GAMBLE_ACTION:
+                j["operation"] = *std::dynamic_pointer_cast<gameplay::GambleAction>(g.operation);
+                break;
+            case gameplay::OperationEnum::PROPERTY_ACTION:
+                j["operation"] = *std::dynamic_pointer_cast<gameplay::PropertyAction>(g.operation);
+                break;
+            case gameplay::OperationEnum::EXFILTRATION:
+                j["operation"] = *std::dynamic_pointer_cast<gameplay::Exfiltration>(g.operation);
+                break;
+            default:
+                j["operation"] = *g.operation;
+                break;
+        }
     }
 
     void from_json(const nlohmann::json &j, GameOperation &g) {
         MessageContainer::common_from_json(j, g);
-        j.at("operation").get_to(g.operation);
+        j.at("operation").get_to(*g.operation);
+        switch (g.operation->getType()) {
+            case spy::gameplay::OperationEnum::MOVEMENT:
+                g.operation = std::make_shared<gameplay::Operation>(j.at("operation").get<gameplay::Movement>());
+                break;
+            case gameplay::OperationEnum::GADGET_ACTION:
+                g.operation = std::make_shared<gameplay::Operation>(j.at("operation").get<gameplay::GadgetAction>());
+                break;
+            case gameplay::OperationEnum::GAMBLE_ACTION:
+                g.operation = std::make_shared<gameplay::Operation>(j.at("operation").get<gameplay::GambleAction>());
+                break;
+            case gameplay::OperationEnum::PROPERTY_ACTION:
+                g.operation = std::make_shared<gameplay::Operation>(j.at("operation").get<gameplay::PropertyAction>());
+                break;
+            case gameplay::OperationEnum::EXFILTRATION:
+                g.operation = std::make_shared<gameplay::Operation>(j.at("operation").get<gameplay::Exfiltration>());
+                break;
+            default:
+                // do nothing
+                break;
+        }
     }
 
-    const gameplay::Operation &GameOperation::getOperation() const {
+    const std::shared_ptr<gameplay::Operation>  &GameOperation::getOperation() const {
         return operation;
     }
 
     bool GameOperation::operator==(const GameOperation &rhs) const {
         return isEqual(rhs) &&
                operation == rhs.operation;
+    }
+
+    bool GameOperation::validate(RoleEnum playerRole, spy::gameplay::State &state) const {
+        if (playerRole == spy::network::RoleEnum::INVALID ||
+            playerRole == spy::network::RoleEnum::SPECTATOR) {
+            return false;
+        }
+
+        spy::gameplay::OperationEnum operationType = operation->getType();
+        if (operationType == spy::gameplay::OperationEnum::INVALID ||
+            operationType == spy::gameplay::OperationEnum::EXFILTRATION ||
+            operationType == spy::gameplay::OperationEnum::CAT_ACTION ||
+            operationType == spy::gameplay::OperationEnum::JANITOR_ACTION) {
+            return false;
+        }
+
+        return spy::gameplay::ActionValidator::validate(state, operation);
+
+        return false;
     }
 }

--- a/src/network/messages/GameOperation.hpp
+++ b/src/network/messages/GameOperation.hpp
@@ -7,15 +7,17 @@
 
 #include <network/MessageContainer.hpp>
 #include <datatypes/gameplay/Operation.hpp>
+#include <network/RoleEnum.hpp>
+#include <datatypes/gameplay/State.hpp>
 
 namespace spy::network::messages {
     class GameOperation : public MessageContainer {
         public:
             GameOperation();
 
-            GameOperation(util::UUID playerId, gameplay::Operation operation);
+            GameOperation(util::UUID playerId, std::shared_ptr<gameplay::Operation> operation);
 
-            [[nodiscard]] const gameplay::Operation &getOperation() const;
+            [[nodiscard]] const std::shared_ptr<gameplay::Operation> &getOperation() const;
 
             friend void to_json(nlohmann::json &j, const GameOperation &g);
 
@@ -23,8 +25,17 @@ namespace spy::network::messages {
 
             bool operator==(const GameOperation &rhs) const;
 
+            /**
+             * validate message according role and operation type and if operation is allowed in current state
+             * @param playerRole role of the player who sent the message
+             * @param state current state of the game
+             * @return true if message is valid
+             *         false if message is not valid
+             */
+            [[nodiscard]] bool validate(RoleEnum playerRole, spy::gameplay::State &state) const;
+
         private:
-            gameplay::Operation operation;
+            std::shared_ptr<gameplay::Operation> operation;
     };
 }
 

--- a/test/gameLogic/movementTests.cpp
+++ b/test/gameLogic/movementTests.cpp
@@ -56,7 +56,6 @@ TEST_F(MovementOperation, isMovementValid) {
     using spy::util::UUID;
     using spy::gameplay::ActionValidator;
     using spy::gameplay::Movement;
-    using spy::gameplay::Operation;
 
     state.getCharacters().getByUUID(uuid1)->setCoordinates({1, 2});
 
@@ -66,11 +65,11 @@ TEST_F(MovementOperation, isMovementValid) {
     Movement move4(false, {1, 1}, UUID(), {1, 2});
     Movement move5(false, {2, 2}, uuid1, {1, 3});
 
-    EXPECT_FALSE(ActionValidator::validate(state, std::make_shared<Operation>(move1)));
-    EXPECT_TRUE(ActionValidator::validate(state, std::make_shared<Operation>(move2)));
-    EXPECT_FALSE(ActionValidator::validate(state, std::make_shared<Operation>(move3)));
-    EXPECT_FALSE(ActionValidator::validate(state, std::make_shared<Operation>(move4)));
-    EXPECT_FALSE(ActionValidator::validate(state, std::make_shared<Operation>(move5)));
+    EXPECT_FALSE(ActionValidator::validate(state, std::make_shared<Movement>(move1)));
+    EXPECT_TRUE(ActionValidator::validate(state, std::make_shared<Movement>(move2)));
+    EXPECT_FALSE(ActionValidator::validate(state, std::make_shared<Movement>(move3)));
+    EXPECT_FALSE(ActionValidator::validate(state, std::make_shared<Movement>(move4)));
+    EXPECT_FALSE(ActionValidator::validate(state, std::make_shared<Movement>(move5)));
 }
 
 TEST_F(MovementOperation, PerformValidate) {

--- a/test/gameLogic/movementTests.cpp
+++ b/test/gameLogic/movementTests.cpp
@@ -56,6 +56,7 @@ TEST_F(MovementOperation, isMovementValid) {
     using spy::util::UUID;
     using spy::gameplay::ActionValidator;
     using spy::gameplay::Movement;
+    using spy::gameplay::Operation;
 
     state.getCharacters().getByUUID(uuid1)->setCoordinates({1, 2});
 
@@ -65,11 +66,11 @@ TEST_F(MovementOperation, isMovementValid) {
     Movement move4(false, {1, 1}, UUID(), {1, 2});
     Movement move5(false, {2, 2}, uuid1, {1, 3});
 
-    EXPECT_FALSE(ActionValidator::validate(state, move1));
-    EXPECT_TRUE(ActionValidator::validate(state, move2));
-    EXPECT_FALSE(ActionValidator::validate(state, move3));
-    EXPECT_FALSE(ActionValidator::validate(state, move4));
-    EXPECT_FALSE(ActionValidator::validate(state, move5));
+    EXPECT_FALSE(ActionValidator::validate(state, std::make_shared<Operation>(move1)));
+    EXPECT_TRUE(ActionValidator::validate(state, std::make_shared<Operation>(move2)));
+    EXPECT_FALSE(ActionValidator::validate(state, std::make_shared<Operation>(move3)));
+    EXPECT_FALSE(ActionValidator::validate(state, std::make_shared<Operation>(move4)));
+    EXPECT_FALSE(ActionValidator::validate(state, std::make_shared<Operation>(move5)));
 }
 
 TEST_F(MovementOperation, PerformValidate) {

--- a/test/messages/messageEncodeDecode.cpp
+++ b/test/messages/messageEncodeDecode.cpp
@@ -103,7 +103,7 @@ TEST_F(MessageEncodeDecode, GameLeft) {
 }
 
 TEST_F(MessageEncodeDecode, GameOperation) {
-    spy::network::messages::GameOperation testMessage{exampleUUID1, exampleOperation};
+    spy::network::messages::GameOperation testMessage{exampleUUID1, std::make_shared<spy::gameplay::Operation>(exampleOperation)};
     testEncodeDecode(testMessage);
 }
 


### PR DESCRIPTION
Was haltet ihr von den fixes?
Das Problem war, dass es in der GameOperation Message nur den Operation Typ gab und keine Spezialisierung davon. Wurde durch einen Pointer gelöst.