### PR TITLE
return optional from Character::getGadget

### DIFF
--- a/src/datatypes/character/Character.cpp
+++ b/src/datatypes/character/Character.cpp
@@ -93,12 +93,16 @@ namespace spy::character {
         Character::gadgets.push_back(std::move(gadget));
     }
 
-    std::shared_ptr<spy::gadget::Gadget> Character::getGadget(spy::gadget::GadgetEnum type) {
+    std::optional<std::shared_ptr<spy::gadget::Gadget>> Character::getGadget(spy::gadget::GadgetEnum type) {
         auto it = std::find_if(gadgets.begin(), gadgets.end(),
                             [&type](const std::shared_ptr<spy::gadget::Gadget> &g) {
                                 return g->getType() == type;
                             });
-        return *it;
+        if (it != gadgets.end()) {
+            return *it;
+        } else {
+            return std::nullopt;                        // character doesn't posses the requested gadget
+        }
     }
 
     void to_json(nlohmann::json &j, const spy::character::Character &c) {

--- a/src/datatypes/character/Character.cpp
+++ b/src/datatypes/character/Character.cpp
@@ -101,7 +101,8 @@ namespace spy::character {
         if (it != gadgets.end()) {
             return *it;
         } else {
-            return std::nullopt;                        // character doesn't posses the requested gadget
+            // character doesn't posses the requested gadget
+            return std::nullopt;
         }
     }
 

--- a/src/datatypes/character/Character.hpp
+++ b/src/datatypes/character/Character.hpp
@@ -99,7 +99,7 @@ namespace spy::character {
 
             [[nodiscard]] bool hasGadget(spy::gadget::GadgetEnum type) const;
 
-            std::shared_ptr<spy::gadget::Gadget> getGadget(spy::gadget::GadgetEnum type);
+            std::optional<std::shared_ptr<spy::gadget::Gadget>> getGadget(spy::gadget::GadgetEnum type);
 
         private:
             spy::util::UUID characterId;

--- a/src/gameLogic/execution/gadget/MothballPouch.cpp
+++ b/src/gameLogic/execution/gadget/MothballPouch.cpp
@@ -25,7 +25,7 @@ namespace spy::gameplay {
 
         // subtract a usage
         auto character = s.getCharacters().getByUUID(a.getCharacterId());
-        auto gadget = character->getGadget(gadget::GadgetEnum::MOTHBALL_POUCH);
+        auto gadget = character->getGadget(gadget::GadgetEnum::MOTHBALL_POUCH).value();
         gadget->setUsagesLeft(gadget->getUsagesLeft().value() - 1);
 
         // remove gadget from inventory if no usages left!


### PR DESCRIPTION
Kleiner PR, der getGadget ein std::optional returnen lässt, sodass nicht mehr angenommen werden muss, dass der Charakter das geforderte Gadget auch wirklich besitzt.