### PR TITLE
Execute with honey trap

### DIFF
--- a/src/datatypes/gameplay/BaseOperation.cpp
+++ b/src/datatypes/gameplay/BaseOperation.cpp
@@ -48,4 +48,8 @@ namespace spy::gameplay {
         return std::tie(type, successful, target) ==
                std::tie(rhs.type, rhs.successful, rhs.target);
     }
+
+    void BaseOperation::setTarget(const util::Point &p) {
+        target = p;
+    }
 }

--- a/src/datatypes/gameplay/BaseOperation.hpp
+++ b/src/datatypes/gameplay/BaseOperation.hpp
@@ -19,6 +19,8 @@ namespace spy::gameplay {
 
             [[nodiscard]] const util::Point &getTarget() const;
 
+            void setTarget(const util::Point &p);
+
             static void common_to_json(nlohmann::json &j, const BaseOperation &op);
 
             static void common_from_json(const nlohmann::json &j, BaseOperation &op);

--- a/src/gameLogic/execution/gadget/BowlerBlade.cpp
+++ b/src/gameLogic/execution/gadget/BowlerBlade.cpp
@@ -11,7 +11,10 @@
 
 namespace spy::gameplay {
 
-    bool GadgetExecutor::executeBowlerBlade(State &s, const GadgetAction &a, const MatchConfig &config) {
+    bool GadgetExecutor::executeBowlerBlade(State &s, const GadgetAction &action, const MatchConfig &config) {
+        //Honey Trap property
+        auto a = util::GameLogicUtils::getHoneyTrapOperation(s, action, config);
+
         auto character = *(s.getCharacters().getByUUID(a.getCharacterId()));
         bool successfullHit = util::GameLogicUtils::probabilityTestWithCharacter(character,
                                                                                  config.getBowlerBladeHitChance());

--- a/src/gameLogic/execution/gadget/Cocktail.cpp
+++ b/src/gameLogic/execution/gadget/Cocktail.cpp
@@ -37,7 +37,11 @@ namespace spy::gameplay {
 
         // cocktail is used on target
         bool ret = false;
-        auto targetChar = util::GameLogicUtils::getInCharacterSetByCoordinates(s.getCharacters(), a.getTarget());
+        //Honey Trap property
+        bool doHoneyTrap = util::GameLogicUtils::isPersonOnField(s, a.getTarget());
+        auto action = doHoneyTrap ? util::GameLogicUtils::getHoneyTrapOperation(s, a, config) : a;
+
+        auto targetChar = util::GameLogicUtils::getInCharacterSetByCoordinates(s.getCharacters(), action.getTarget());
         bool dodged = util::GameLogicUtils::probabilityTestWithCharacter(*targetChar, config.getCocktailDodgeChance());
 
         if (!dodged) {

--- a/src/gameLogic/execution/gadget/GadgetExecutor.cpp
+++ b/src/gameLogic/execution/gadget/GadgetExecutor.cpp
@@ -52,6 +52,5 @@ namespace spy::gameplay {
             default:
                 throw std::invalid_argument("Execution of gadget type not implemented");
         }
-        return false;
     }
 }

--- a/src/gameLogic/execution/gadget/GadgetExecutor.cpp
+++ b/src/gameLogic/execution/gadget/GadgetExecutor.cpp
@@ -11,7 +11,7 @@ namespace spy::gameplay {
             case gadget::GadgetEnum::HAIRDRYER:
                 return executeHairDryer(s, action);
             case gadget::GadgetEnum::MOLEDIE:
-                break;
+                return executeMoleDie(s, action, config);
             case gadget::GadgetEnum::TECHNICOLOUR_PRISM:
                 break;
             case gadget::GadgetEnum::BOWLER_BLADE:
@@ -19,7 +19,7 @@ namespace spy::gameplay {
             case gadget::GadgetEnum::MAGNETIC_WATCH:
                 break;
             case gadget::GadgetEnum::POISON_PILLS:
-                break;
+                return executePoisonPills(s, action, config);
             case gadget::GadgetEnum::LASER_COMPACT:
                 break;
             case gadget::GadgetEnum::ROCKET_PEN:

--- a/src/gameLogic/execution/gadget/GadgetExecutor.cpp
+++ b/src/gameLogic/execution/gadget/GadgetExecutor.cpp
@@ -6,7 +6,6 @@
 
 namespace spy::gameplay {
     bool GadgetExecutor::execute(State &s, GadgetAction action, const MatchConfig &config) {
-        // TODO: implement
         switch (action.getGadget()) {
             case gadget::GadgetEnum::HAIRDRYER:
                 return executeHairDryer(s, action);
@@ -43,7 +42,7 @@ namespace spy::gameplay {
             case gadget::GadgetEnum::MIRROR_OF_WILDERNESS:
                 return executeMirrorOfWilderness(s, action, config);
             case gadget::GadgetEnum::COCKTAIL:
-                break;
+                return executeCocktail(s, action, config);
             case gadget::GadgetEnum::POCKET_LITTER:
                 [[fallthrough]];
             case gadget::GadgetEnum::MAGNETIC_WATCH:

--- a/src/gameLogic/execution/gadget/GadgetExecutor.hpp
+++ b/src/gameLogic/execution/gadget/GadgetExecutor.hpp
@@ -49,13 +49,13 @@ namespace spy::gameplay {
 
             static bool executeRocketPen(State &s, const GadgetAction &a, const MatchConfig &config);
 
-            static bool executeMoleDie(State &s, const GadgetAction &a);
+            static bool executeMoleDie(State &s, const GadgetAction &a, const MatchConfig &config);
 
             static bool executeFogTin(State &s, const GadgetAction &a);
 
             static bool executeDiamondCollar(State &s, const GadgetAction &a);
 
-            static bool executePoisonPills(State &s, const GadgetAction &a);
+            static bool executePoisonPills(State &s, const GadgetAction &a, const MatchConfig & config);
       
             static bool executeMothballPouch(State &s, const GadgetAction &a, const MatchConfig &config);
 

--- a/src/gameLogic/execution/gadget/GasGloss.cpp
+++ b/src/gameLogic/execution/gadget/GasGloss.cpp
@@ -7,7 +7,10 @@
 
 namespace spy::gameplay {
 
-    bool GadgetExecutor::executeGasGloss(State &s, const GadgetAction &a, const MatchConfig &config) {
+    bool GadgetExecutor::executeGasGloss(State &s, const GadgetAction &action, const MatchConfig &config) {
+        //Honey Trap property
+        auto a = util::GameLogicUtils::getHoneyTrapOperation(s, action, config);
+
         auto character = s.getCharacters().getByUUID(a.getCharacterId());
 
         // Babysitter successfull

--- a/src/gameLogic/execution/gadget/LaserCompact.cpp
+++ b/src/gameLogic/execution/gadget/LaserCompact.cpp
@@ -10,7 +10,10 @@
 
 namespace spy::gameplay {
 
-    bool GadgetExecutor::executeLaserCompact(State &s, const GadgetAction &a, const MatchConfig &config) {
+    bool GadgetExecutor::executeLaserCompact(State &s, const GadgetAction &action, const MatchConfig &config) {
+        //Honey Trap property
+        auto a = util::GameLogicUtils::getHoneyTrapOperation(s, action, config);
+
         auto character = s.getCharacters().getByUUID(a.getCharacterId());
         // check if shot hit
         bool hitSuccessful = util::GameLogicUtils::probabilityTestWithCharacter(*character,

--- a/src/gameLogic/execution/gadget/MoleDie.cpp
+++ b/src/gameLogic/execution/gadget/MoleDie.cpp
@@ -30,7 +30,7 @@ namespace spy::gameplay {
         }
 
         // mole die bounces into the inventory of the closest person
-        auto closestPoint = util::GameLogicUtils::getRandomCharacterNearField(s, a.getTarget());
+        auto closestPoint = util::GameLogicUtils::getRandomCharacterNearField(s, action.getTarget());
         auto closestPerson = util::GameLogicUtils::getInCharacterSetByCoordinates(s.getCharacters(), closestPoint);
 
         closestPerson->addGadget(std::make_shared<gadget::Gadget>(GadgetEnum::MOLEDIE));

--- a/src/gameLogic/execution/gadget/MoleDie.cpp
+++ b/src/gameLogic/execution/gadget/MoleDie.cpp
@@ -10,18 +10,22 @@
 
 namespace spy::gameplay {
 
-    bool GadgetExecutor::executeMoleDie(State &s, const GadgetAction &a) {
+    bool GadgetExecutor::executeMoleDie(State &s, const GadgetAction &action, const MatchConfig &config) {
         using spy::gadget::GadgetEnum;
 
         // character that issues the action and remove mole die from their inventory
-        auto character = s.getCharacters().getByUUID(a.getCharacterId());
+        auto character = s.getCharacters().getByUUID(action.getCharacterId());
         character->removeGadget(GadgetEnum::MOLEDIE);
 
         // check if target field has character
-        auto person = util::GameLogicUtils::getInCharacterSetByCoordinates(s.getCharacters(), a.getTarget());
+        auto person = util::GameLogicUtils::getInCharacterSetByCoordinates(s.getCharacters(), action.getTarget());
         if (person != s.getCharacters().end()) {
+            //Honey Trap property
+            auto a = util::GameLogicUtils::getHoneyTrapOperation(s, action, config);
+
+            auto targetPerson = util::GameLogicUtils::getInCharacterSetByCoordinates(s.getCharacters(), a.getTarget());
             // mole die goes into the person inventory
-            person->addGadget(std::make_shared<gadget::Gadget>(GadgetEnum::MOLEDIE));
+            targetPerson->addGadget(std::make_shared<gadget::Gadget>(GadgetEnum::MOLEDIE));
             return true;
         }
 

--- a/src/gameLogic/execution/gadget/PoisonPills.cpp
+++ b/src/gameLogic/execution/gadget/PoisonPills.cpp
@@ -12,7 +12,11 @@
 
 namespace spy::gameplay {
 
-    bool GadgetExecutor::executePoisonPills(State &s, const GadgetAction &a) {
+    bool GadgetExecutor::executePoisonPills(State &s, const GadgetAction &action, const MatchConfig & config) {
+        //Honey Trap property
+        bool doHoneyTrap = util::GameLogicUtils::isPersonOnField(s, action.getTarget());
+        auto a = doHoneyTrap ? util::GameLogicUtils::getHoneyTrapOperation(s, action, config) : action;
+        
         // check if person on field
         bool personOnField = util::GameLogicUtils::isPersonOnField(s, a.getTarget());
 

--- a/src/gameLogic/execution/gadget/PoisonPills.cpp
+++ b/src/gameLogic/execution/gadget/PoisonPills.cpp
@@ -16,7 +16,7 @@ namespace spy::gameplay {
         //Honey Trap property
         bool doHoneyTrap = util::GameLogicUtils::isPersonOnField(s, action.getTarget());
         auto a = doHoneyTrap ? util::GameLogicUtils::getHoneyTrapOperation(s, action, config) : action;
-        
+
         // check if person on field
         bool personOnField = util::GameLogicUtils::isPersonOnField(s, a.getTarget());
 

--- a/src/gameLogic/execution/gadget/RocketPen.cpp
+++ b/src/gameLogic/execution/gadget/RocketPen.cpp
@@ -10,7 +10,11 @@
 
 namespace spy::gameplay {
 
-    bool GadgetExecutor::executeRocketPen(State &s, const GadgetAction &a, const MatchConfig &config) {
+    bool GadgetExecutor::executeRocketPen(State &s, const GadgetAction &action, const MatchConfig &config) {
+        //Honey Trap property
+        bool doHoneyTrap = util::GameLogicUtils::isPersonOnField(s, action.getTarget());
+        auto a = doHoneyTrap ? util::GameLogicUtils::getHoneyTrapOperation(s, action, config) : action;
+
         // destroy potential wall on target field
         bool targetHasWall = (s.getMap().getField(a.getTarget()).getFieldState() == scenario::FieldStateEnum::WALL);
         if (targetHasWall) {

--- a/src/util/GameLogicUtils.cpp
+++ b/src/util/GameLogicUtils.cpp
@@ -222,7 +222,7 @@ namespace spy::util {
             auto otherTarget = it->getCoordinates().value();
             if (s.getMap().isInside(otherTarget)) {
                 a.setTarget(otherTarget);
-                if (gameplay::ActionValidator::validate(s, a, config)) {
+                if (gameplay::ActionValidator::validate(s, std::make_shared<gameplay::GadgetAction>(a), config)) {
                     alternativeTargets.push_back(otherTarget);
                 }
             }

--- a/src/util/GameLogicUtils.cpp
+++ b/src/util/GameLogicUtils.cpp
@@ -224,7 +224,7 @@ namespace spy::util {
         return resultChar;
     }
 
-    const gameplay::GadgetAction
+    gameplay::GadgetAction
     GameLogicUtils::getHoneyTrapOperation(const gameplay::State &s, const gameplay::GadgetAction &op,
                                           const MatchConfig &config) {
 

--- a/src/util/GameLogicUtils.cpp
+++ b/src/util/GameLogicUtils.cpp
@@ -203,14 +203,18 @@ namespace spy::util {
     std::optional<std::shared_ptr<character::Character>>
     GameLogicUtils::getWiredCharacter(const gameplay::State &s, const character::Character gettingIP) {
         std::optional<std::shared_ptr<character::Character>> resultChar;
-        auto character = std::find_if(s.getCharacters().begin(), s.getCharacters().end(), [&gettingIP](const character::Character &c) {
-            auto gadget_optionalPointer = c.getGadget(gadget::GadgetEnum::WIRETAP_WITH_EARPLUGS);
-            if (!gadget_optionalPointer.has_value()) {
-                return false;
-            }
-            auto gadget = *std::dynamic_pointer_cast<const gadget::WiretapWithEarplugs>(gadget_optionalPointer.value());
-            return gadget.isWorking() && gadget.getActiveOn().has_value() && gadget.getActiveOn().value() == gettingIP.getCharacterId();
-        });
+        auto character = std::find_if(s.getCharacters().begin(), s.getCharacters().end(),
+                                      [&gettingIP](const character::Character &c) {
+                                          auto gadget_optionalPointer = c.getGadget(
+                                                  gadget::GadgetEnum::WIRETAP_WITH_EARPLUGS);
+                                          if (!gadget_optionalPointer.has_value()) {
+                                              return false;
+                                          }
+                                          auto gadget = *std::dynamic_pointer_cast<const gadget::WiretapWithEarplugs>(
+                                                  gadget_optionalPointer.value());
+                                          return gadget.isWorking() && gadget.getActiveOn().has_value() &&
+                                                 gadget.getActiveOn().value() == gettingIP.getCharacterId();
+                                      });
 
         if (character != s.getCharacters().end()) {
             //character getting intelligence points is wired
@@ -236,8 +240,9 @@ namespace spy::util {
         std::vector<Point> alternativeTargets;
         for (const auto &character: s.getCharacters()) {
             if (character.getCharacterId() == sourceChar->getCharacterId() ||
-                character.getCharacterId() == targetChar->getCharacterId()) {
-                // alternative action target is source or target
+                character.getCharacterId() == targetChar->getCharacterId() ||
+                !character.getCoordinates().has_value()) {
+                // alternative action target is source or target or not in map
                 continue;
             }
 

--- a/src/util/GameLogicUtils.cpp
+++ b/src/util/GameLogicUtils.cpp
@@ -212,14 +212,14 @@ namespace spy::util {
         }
 
         std::vector<Point> alternativeTargets;
-        for (auto it = s.getCharacters().begin(); it != s.getCharacters().end(); it++) {
-            if (it->getCharacterId() == sourceChar->getCharacterId() ||
-                it->getCharacterId() == targetChar->getCharacterId()) {
-                // alternative action target is not source or target
+        for (const auto &character: s.getCharacters()) {
+            if (character.getCharacterId() == sourceChar->getCharacterId() ||
+                character.getCharacterId() == targetChar->getCharacterId()) {
+                // alternative action target is source or target
                 continue;
             }
 
-            auto otherTarget = it->getCoordinates().value();
+            auto otherTarget = character.getCoordinates().value();
             if (s.getMap().isInside(otherTarget)) {
                 a.setTarget(otherTarget);
                 if (gameplay::ActionValidator::validate(s, std::make_shared<gameplay::GadgetAction>(a), config)) {
@@ -237,4 +237,3 @@ namespace spy::util {
         return a;
     }
 }
-

--- a/src/util/GameLogicUtils.hpp
+++ b/src/util/GameLogicUtils.hpp
@@ -188,7 +188,7 @@ namespace spy::util {
                 auto field = s.getMap().getMap();
                 for (unsigned int y = 0; y < field.size(); y++) {
                     for (unsigned int x = 0; x < field.at(y).size(); x++) {
-                        Point p {(int)x, (int)y};
+                        Point p{(int) x, (int) y};
                         if (isSearchedField(p)) {
                             result.push_back(p);
                         }
@@ -245,6 +245,16 @@ namespace spy::util {
              * @param damage        unmodified damage value
              */
             static void applyDamageToCharacter(character::Character &targetChar, unsigned int damage);
+
+            /**
+             * @brief get operation that might change due to honey trap property (probability test must have been successful)
+             * @param s current state
+             * @param op Operation that targets a character with successful honey trap porbability test
+             * @return resulting operation after honey trap was checked and applied
+             */
+            static std::shared_ptr<const gameplay::BaseOperation>
+            getHoneyTrapOperation(const gameplay::State &s, std::shared_ptr<const gameplay::BaseOperation> &op,
+                                  const MatchConfig &config);
     };
 }
 

--- a/src/util/GameLogicUtils.hpp
+++ b/src/util/GameLogicUtils.hpp
@@ -13,6 +13,7 @@
 #include "datatypes/gameplay/State.hpp"
 #include "matchconfig/MatchConfig.hpp"
 #include "gameplay/CharacterOperation.hpp"
+#include "gameplay/GadgetAction.hpp"
 
 namespace spy::util {
     class GameLogicUtils {

--- a/src/util/GameLogicUtils.hpp
+++ b/src/util/GameLogicUtils.hpp
@@ -253,7 +253,7 @@ namespace spy::util {
              * @param op GadgetOperation that targets a character
              * @return resulting GadgetOperation after honey trap was checked and applied
              */
-            static const gameplay::GadgetAction
+            static gameplay::GadgetAction
             getHoneyTrapOperation(const gameplay::State &s, const gameplay::GadgetAction &op,
                                    const MatchConfig &config);
 

--- a/src/util/GameLogicUtils.hpp
+++ b/src/util/GameLogicUtils.hpp
@@ -247,14 +247,14 @@ namespace spy::util {
             static void applyDamageToCharacter(character::Character &targetChar, unsigned int damage);
 
             /**
-             * @brief get operation that might change due to honey trap property (probability test must have been successful)
+             * @brief get operation that might change due to possible honey trap property
              * @param s current state
-             * @param op Operation that targets a character with successful honey trap porbability test
-             * @return resulting operation after honey trap was checked and applied
+             * @param op GadgetOperation that targets a character
+             * @return resulting GadgetOperation after honey trap was checked and applied
              */
-            static std::shared_ptr<const gameplay::BaseOperation>
-            getHoneyTrapOperation(const gameplay::State &s, std::shared_ptr<const gameplay::BaseOperation> &op,
-                                  const MatchConfig &config);
+            static const gameplay::GadgetAction
+            getHoneyTrapOperation(const gameplay::State &s, const gameplay::GadgetAction &op,
+                                   const MatchConfig &config);
     };
 }
 


### PR DESCRIPTION
fixes #201 
Es ist noch zu klären, welche Aktionen auf Honey Trap testen müssen.
Aktueller Stand ist:
- [x] Cocktail, aber nur verschütten (execution ist noch nicht im develop)
- [x] Poison Pills, aber nur wenn man den Cocktail hält
- [x] Bowler Blade
- [x] Gas Gloss
- [x] Laser Compact
- [x] Mode Die, aber nur wenn auf Person geworfen wird
- [x] Rocket Pen, aber nur wenn auf Person geschossen
* Nugget (würde ich nicht machen)
* Mirror of Wilderness (würde ich nicht machen)
* Wiretrap with Earplugs  (würde ich nicht machen)
* Hair Dryer (würde ich nicht machen)

