### PR TITLE
rework of EquipmentChoice validate

### DIFF
--- a/src/network/messages/EquipmentChoice.cpp
+++ b/src/network/messages/EquipmentChoice.cpp
@@ -47,18 +47,11 @@ namespace spy::network::messages {
             if (charIt == chosenCharacter.end()) {
                 return false;
             }
-
-            // check if the gadget set is part of the chosen ones
-            for (const auto &g : gadgets) {
-                auto gadgetIt = std::find(chosenGadget.begin(), chosenGadget.end(), g);
-                if (gadgetIt == chosenGadget.end()) {
-                    return false;
-                } else {
-                    *gadgetIt = spy::gadget::GadgetEnum::INVALID;
-                }
-            }
         }
 
-        return true;
+        std::sort(chosenGadget.begin(), chosenGadget.end());
+        std::sort(mapGadgets.begin(), mapGadgets.end());
+
+        return (chosenGadget == mapGadgets);
     }
 }

--- a/src/network/messages/EquipmentChoice.cpp
+++ b/src/network/messages/EquipmentChoice.cpp
@@ -38,7 +38,6 @@ namespace spy::network::messages {
             return false;
         }
 
-        std::vector<util::UUID> mapCharacters;
         std::vector<gadget::GadgetEnum> mapGadgets;
 
         for (const auto &[character, gadgets] : equipment) {
@@ -47,6 +46,7 @@ namespace spy::network::messages {
             if (charIt == chosenCharacter.end()) {
                 return false;
             }
+            mapGadgets.insert(mapGadgets.end(), gadgets.begin(), gadgets.end());
         }
 
         std::sort(chosenGadget.begin(), chosenGadget.end());

--- a/src/network/messages/EquipmentChoice.cpp
+++ b/src/network/messages/EquipmentChoice.cpp
@@ -42,15 +42,23 @@ namespace spy::network::messages {
         std::vector<gadget::GadgetEnum> mapGadgets;
 
         for (const auto &[character, gadgets] : equipment) {
-            mapCharacters.push_back(character);
-            mapGadgets.insert(mapGadgets.end(), gadgets.begin(), gadgets.end());
+            // check if character is part of the chosen ones
+            auto charIt = std::find(chosenCharacter.begin(), chosenCharacter.end(), character);
+            if (charIt == chosenCharacter.end()) {
+                return false;
+            }
+
+            // check if the gadget set is part of the chosen ones
+            for (const auto &g : gadgets) {
+                auto gadgetIt = std::find(chosenGadget.begin(), chosenGadget.end(), g);
+                if (gadgetIt == chosenGadget.end()) {
+                    return false;
+                } else {
+                    *gadgetIt = spy::gadget::GadgetEnum::INVALID;
+                }
+            }
         }
 
-        std::sort(chosenCharacter.begin(), chosenCharacter.end());
-        std::sort(mapCharacters.begin(), mapCharacters.end());
-        std::sort(chosenGadget.begin(), chosenGadget.end());
-        std::sort(mapGadgets.begin(), mapGadgets.end());
-
-        return (chosenCharacter == mapCharacters && chosenGadget == mapGadgets);
+        return true;
     }
 }

--- a/test/messages/messageValidateTest.cpp
+++ b/test/messages/messageValidateTest.cpp
@@ -113,27 +113,27 @@ TEST(messages, EquipmentChoiceMessage_validate) {
             {spy::util::UUID{
                     "123e4567-e89b-12d3-a456-426655440001"}, {spy::gadget::GadgetEnum::BOWLER_BLADE, spy::gadget::GadgetEnum::CHICKEN_FEED}}
     };
-    std::map<spy::util::UUID, std::set<spy::gadget::GadgetEnum>> mapCor4{
+    std::map<spy::util::UUID, std::set<spy::gadget::GadgetEnum>> mapFalse1{
             {spy::util::UUID{"123e4567-e89b-12d3-a456-426655440001"}, {spy::gadget::GadgetEnum::BOWLER_BLADE}},
             {spy::util::UUID{"123e4567-e89b-12d3-a456-426655440000"}, {}}
     };
-    std::map<spy::util::UUID, std::set<spy::gadget::GadgetEnum>> mapFalse1{
+    std::map<spy::util::UUID, std::set<spy::gadget::GadgetEnum>> mapFalse2{
             {spy::util::UUID{
                     "123e4567-e89b-12d3-a456-426655440001"},          {spy::gadget::GadgetEnum::BOWLER_BLADE, spy::gadget::GadgetEnum::CHICKEN_FEED}},
             {spy::util::UUID{"123e4567-e89b-12d3-a456-426655440000"}, {spy::gadget::GadgetEnum::BOWLER_BLADE}}
     };
-    std::map<spy::util::UUID, std::set<spy::gadget::GadgetEnum>> mapFalse2{
+    std::map<spy::util::UUID, std::set<spy::gadget::GadgetEnum>> mapFalse3{
             {spy::util::UUID{
-                    "123e4567-e89b-12d3-a456-426655440000"},          {spy::gadget::GadgetEnum::BOWLER_BLADE, spy::gadget::GadgetEnum::CHICKEN_FEED}},
+                    "123e4567-e89b-12d3-a456-426655440005"},          {spy::gadget::GadgetEnum::CHICKEN_FEED}},
             {spy::util::UUID{"123e4567-e89b-12d3-a456-426655440001"}, {spy::gadget::GadgetEnum::BOWLER_BLADE}}
     };
 
     spy::network::messages::EquipmentChoice mCor1(spy::util::UUID{}, mapCor1);
     spy::network::messages::EquipmentChoice mCor2(spy::util::UUID{}, mapCor2);
     spy::network::messages::EquipmentChoice mCor3(spy::util::UUID{}, mapCor3);
-    spy::network::messages::EquipmentChoice mCor4(spy::util::UUID{}, mapCor4);
     spy::network::messages::EquipmentChoice mFalse1(spy::util::UUID{}, mapFalse1);
     spy::network::messages::EquipmentChoice mFalse2(spy::util::UUID{}, mapFalse2);
+    spy::network::messages::EquipmentChoice mFalse3(spy::util::UUID{}, mapFalse3);
 
     EXPECT_TRUE(mCor1.validate(spy::network::RoleEnum::PLAYER, offeredCharacters, offeredGadgets));
     EXPECT_TRUE(mCor1.validate(spy::network::RoleEnum::AI, offeredCharacters, offeredGadgets));
@@ -146,15 +146,14 @@ TEST(messages, EquipmentChoiceMessage_validate) {
     EXPECT_TRUE(mCor3.validate(spy::network::RoleEnum::PLAYER, offeredCharacters, offeredGadgets));
     EXPECT_FALSE(mCor3.validate(spy::network::RoleEnum::SPECTATOR, offeredCharacters, offeredGadgets));
 
-    EXPECT_TRUE(mCor4.validate(spy::network::RoleEnum::PLAYER, offeredCharacters, offeredGadgets));
-    EXPECT_FALSE(mCor4.validate(spy::network::RoleEnum::SPECTATOR, offeredCharacters, offeredGadgets));
-
     EXPECT_FALSE(mFalse1.validate(spy::network::RoleEnum::PLAYER, offeredCharacters, offeredGadgets));
     EXPECT_FALSE(mFalse1.validate(spy::network::RoleEnum::AI, offeredCharacters, offeredGadgets));
     EXPECT_FALSE(mFalse1.validate(spy::network::RoleEnum::INVALID, offeredCharacters, offeredGadgets));
     EXPECT_FALSE(mFalse1.validate(spy::network::RoleEnum::SPECTATOR, offeredCharacters, offeredGadgets));
 
     EXPECT_FALSE(mFalse2.validate(spy::network::RoleEnum::PLAYER, offeredCharacters, offeredGadgets));
+
+    EXPECT_FALSE(mFalse3.validate(spy::network::RoleEnum::PLAYER, offeredCharacters, offeredGadgets));
 }
 
 

--- a/test/messages/messageValidateTest.cpp
+++ b/test/messages/messageValidateTest.cpp
@@ -109,25 +109,31 @@ TEST(messages, EquipmentChoiceMessage_validate) {
             {spy::util::UUID{"123e4567-e89b-12d3-a456-426655440001"}, {spy::gadget::GadgetEnum::BOWLER_BLADE}},
             {spy::util::UUID{"123e4567-e89b-12d3-a456-426655440000"}, {spy::gadget::GadgetEnum::CHICKEN_FEED}}
     };
-    std::map<spy::util::UUID, std::set<spy::gadget::GadgetEnum>> mapFalse1{
+    std::map<spy::util::UUID, std::set<spy::gadget::GadgetEnum>> mapCor3{
             {spy::util::UUID{
                     "123e4567-e89b-12d3-a456-426655440001"}, {spy::gadget::GadgetEnum::BOWLER_BLADE, spy::gadget::GadgetEnum::CHICKEN_FEED}}
     };
-    std::map<spy::util::UUID, std::set<spy::gadget::GadgetEnum>> mapFalse2{
+    std::map<spy::util::UUID, std::set<spy::gadget::GadgetEnum>> mapCor4{
             {spy::util::UUID{"123e4567-e89b-12d3-a456-426655440001"}, {spy::gadget::GadgetEnum::BOWLER_BLADE}},
             {spy::util::UUID{"123e4567-e89b-12d3-a456-426655440000"}, {}}
     };
-    std::map<spy::util::UUID, std::set<spy::gadget::GadgetEnum>> mapFalse3{
+    std::map<spy::util::UUID, std::set<spy::gadget::GadgetEnum>> mapFalse1{
             {spy::util::UUID{
                     "123e4567-e89b-12d3-a456-426655440001"},          {spy::gadget::GadgetEnum::BOWLER_BLADE, spy::gadget::GadgetEnum::CHICKEN_FEED}},
             {spy::util::UUID{"123e4567-e89b-12d3-a456-426655440000"}, {spy::gadget::GadgetEnum::BOWLER_BLADE}}
     };
+    std::map<spy::util::UUID, std::set<spy::gadget::GadgetEnum>> mapFalse2{
+            {spy::util::UUID{
+                    "123e4567-e89b-12d3-a456-426655440000"},          {spy::gadget::GadgetEnum::BOWLER_BLADE, spy::gadget::GadgetEnum::CHICKEN_FEED}},
+            {spy::util::UUID{"123e4567-e89b-12d3-a456-426655440001"}, {spy::gadget::GadgetEnum::BOWLER_BLADE}}
+    };
 
     spy::network::messages::EquipmentChoice mCor1(spy::util::UUID{}, mapCor1);
     spy::network::messages::EquipmentChoice mCor2(spy::util::UUID{}, mapCor2);
+    spy::network::messages::EquipmentChoice mCor3(spy::util::UUID{}, mapCor3);
+    spy::network::messages::EquipmentChoice mCor4(spy::util::UUID{}, mapCor4);
     spy::network::messages::EquipmentChoice mFalse1(spy::util::UUID{}, mapFalse1);
     spy::network::messages::EquipmentChoice mFalse2(spy::util::UUID{}, mapFalse2);
-    spy::network::messages::EquipmentChoice mFalse3(spy::util::UUID{}, mapFalse3);
 
     EXPECT_TRUE(mCor1.validate(spy::network::RoleEnum::PLAYER, offeredCharacters, offeredGadgets));
     EXPECT_TRUE(mCor1.validate(spy::network::RoleEnum::AI, offeredCharacters, offeredGadgets));
@@ -137,13 +143,18 @@ TEST(messages, EquipmentChoiceMessage_validate) {
     EXPECT_TRUE(mCor2.validate(spy::network::RoleEnum::PLAYER, offeredCharacters, offeredGadgets));
     EXPECT_FALSE(mCor2.validate(spy::network::RoleEnum::SPECTATOR, offeredCharacters, offeredGadgets));
 
+    EXPECT_TRUE(mCor3.validate(spy::network::RoleEnum::PLAYER, offeredCharacters, offeredGadgets));
+    EXPECT_FALSE(mCor3.validate(spy::network::RoleEnum::SPECTATOR, offeredCharacters, offeredGadgets));
+
+    EXPECT_TRUE(mCor4.validate(spy::network::RoleEnum::PLAYER, offeredCharacters, offeredGadgets));
+    EXPECT_FALSE(mCor4.validate(spy::network::RoleEnum::SPECTATOR, offeredCharacters, offeredGadgets));
+
     EXPECT_FALSE(mFalse1.validate(spy::network::RoleEnum::PLAYER, offeredCharacters, offeredGadgets));
     EXPECT_FALSE(mFalse1.validate(spy::network::RoleEnum::AI, offeredCharacters, offeredGadgets));
     EXPECT_FALSE(mFalse1.validate(spy::network::RoleEnum::INVALID, offeredCharacters, offeredGadgets));
     EXPECT_FALSE(mFalse1.validate(spy::network::RoleEnum::SPECTATOR, offeredCharacters, offeredGadgets));
 
     EXPECT_FALSE(mFalse2.validate(spy::network::RoleEnum::PLAYER, offeredCharacters, offeredGadgets));
-    EXPECT_FALSE(mFalse3.validate(spy::network::RoleEnum::PLAYER, offeredCharacters, offeredGadgets));
 }
 
 


### PR DESCRIPTION
Validierung lässt nun auch Nachrichten zu, in denen nicht alle Charakter und Gadgets verwendet werden.