### PR TITLE
added usagesLeft initialization according to type

### DIFF
--- a/src/datatypes/gadgets/Gadget.cpp
+++ b/src/datatypes/gadgets/Gadget.cpp
@@ -6,7 +6,60 @@
 
 namespace spy::gadget {
 
-    Gadget::Gadget(GadgetEnum type, int usagesLeft) : type(type), usagesLeft(usagesLeft) {}
+    Gadget::Gadget(GadgetEnum type) : type(type) {
+        switch (type) {
+            case GadgetEnum::HAIRDRYER:
+                [[fallthrough]];
+            case GadgetEnum::BOWLER_BLADE:
+                [[fallthrough]];
+            case GadgetEnum::MAGNETIC_WATCH:
+                [[fallthrough]];
+            case GadgetEnum::LASER_COMPACT:
+                [[fallthrough]];
+            case GadgetEnum::GRAPPLE:
+                [[fallthrough]];
+            case GadgetEnum::DIAMOND_COLLAR:
+                [[fallthrough]];
+            case GadgetEnum::POCKET_LITTER:
+                [[fallthrough]];
+            case GadgetEnum::MOLEDIE:
+                usagesLeft = std::nullopt;
+                break;
+
+
+            case GadgetEnum::NUGGET:
+                [[fallthrough]];
+            case GadgetEnum::TECHNICOLOUR_PRISM:
+                [[fallthrough]];
+            case GadgetEnum::ROCKET_PEN:
+                [[fallthrough]];
+            case GadgetEnum::GAS_GLOSS:
+                [[fallthrough]];
+            case GadgetEnum::WIRETAP_WITH_EARPLUGS:
+                [[fallthrough]];
+            case GadgetEnum::JETPACK:
+                [[fallthrough]];
+            case GadgetEnum::CHICKEN_FEED:
+                [[fallthrough]];
+            case GadgetEnum::COCKTAIL:
+                [[fallthrough]];
+            case GadgetEnum::FOG_TIN:
+                usagesLeft = 1;
+                break;
+
+            case GadgetEnum::MOTHBALL_POUCH:
+                [[fallthrough]];
+            case GadgetEnum::POISON_PILLS:
+                usagesLeft = 5;
+                break;
+
+            default:
+                usagesLeft = 0;
+                break;
+        }
+    }
+
+    Gadget::Gadget(GadgetEnum type, unsigned int usagesLeft) : type(type), usagesLeft(usagesLeft) {}
 
     GadgetEnum Gadget::getType() const {
         return type;

--- a/src/datatypes/gadgets/Gadget.hpp
+++ b/src/datatypes/gadgets/Gadget.hpp
@@ -1,6 +1,9 @@
-//
-// Created by jonas on 02.04.20.
-//
+/**
+ * @file   Gadget.hpp
+ * @author Jonas Otto
+ * @date   02.04.20 (creation)
+ * @brief  Declaration of the gadget class.
+ */
 
 #ifndef LIBCOMMON_GADGET_HPP
 #define LIBCOMMON_GADGET_HPP
@@ -15,7 +18,9 @@ namespace spy::gadget {
         public:
             Gadget() : type{GadgetEnum::INVALID}, usagesLeft{0} {};
 
-            explicit Gadget(GadgetEnum type, int usagesLeft = 0);
+            explicit Gadget(GadgetEnum type);
+
+            Gadget(GadgetEnum type, unsigned int usagesLeft);
 
             virtual ~Gadget() = default;
 


### PR DESCRIPTION
fixes #277 

Bisher wird die Anzahl der verbleibenden Nutzungen nur in den Tests gesetzt, sodass die Gadgets durch den default Wert vermutlich immer mit Null verbleibenden Nutzungen initialisiert, auch wenn die Gadgets eigentlich unendlich viele haben. 
Wirklich relevant sollte das nur bei den Gadgets sein, die ne endliche Nutzungsdauer haben, da dieser bei der Ausführung dekrementiert wird. Der Vollständigkeit halber wird das nun für alle gesetzt.