### PR TITLE
[FIX] added initialization of optional elements of the roulette table

### DIFF
--- a/src/datatypes/scenario/Field.cpp
+++ b/src/datatypes/scenario/Field.cpp
@@ -12,11 +12,7 @@
 namespace spy::scenario {
 
     Field::Field(FieldStateEnum fieldState) : state(fieldState) {
-        if (fieldState == FieldStateEnum::ROULETTE_TABLE) {
-            Field::inverted   = false;
-            Field::destroyed  = false;
-            Field::chipAmount = 0;
-        }
+        initializeOptionals(fieldState);
     }
 
     void Field::setFieldState(FieldStateEnum fieldState) {
@@ -24,21 +20,7 @@ namespace spy::scenario {
             Field::updated = true;
             Field::state = fieldState;
 
-            if (fieldState != FieldStateEnum::ROULETTE_TABLE) {
-                Field::inverted.reset();
-                Field::destroyed.reset();
-                Field::chipAmount.reset();
-            }
-
-            if (fieldState != FieldStateEnum::SAFE) {
-                Field::safeIndex.reset();
-            }
-
-            if (fieldState == FieldStateEnum::ROULETTE_TABLE) {
-                Field::inverted   = false;
-                Field::destroyed  = false;
-                Field::chipAmount = 0;
-            }
+            initializeOptionals(fieldState);
         }
     }
 
@@ -200,5 +182,23 @@ namespace spy::scenario {
         return std::tie(state, gadget, destroyed, inverted, chipAmount, safeIndex, foggy, updated) ==
                std::tie(rhs.state, rhs.gadget, rhs.destroyed, rhs.inverted, rhs.chipAmount, rhs.safeIndex, rhs.foggy,
                         rhs.updated);
+    }
+
+    void Field::initializeOptionals(FieldStateEnum fieldState) {
+        if (fieldState == FieldStateEnum::ROULETTE_TABLE) {
+            Field::inverted   = false;
+            Field::destroyed  = false;
+            Field::chipAmount = 0;
+        } else {
+            Field::inverted.reset();
+            Field::destroyed.reset();
+            Field::chipAmount.reset();
+        }
+
+        if (fieldState != FieldStateEnum::SAFE) {
+            Field::safeIndex.reset();
+        } else {
+            Field::safeIndex = 0;
+        }
     }
 }

--- a/src/datatypes/scenario/Field.cpp
+++ b/src/datatypes/scenario/Field.cpp
@@ -11,7 +11,13 @@
 
 namespace spy::scenario {
 
-    Field::Field(FieldStateEnum fieldState) : state(fieldState) {}
+    Field::Field(FieldStateEnum fieldState) : state(fieldState) {
+        if (fieldState == FieldStateEnum::ROULETTE_TABLE) {
+            Field::inverted   = false;
+            Field::destroyed  = false;
+            Field::chipAmount = 0;
+        }
+    }
 
     void Field::setFieldState(FieldStateEnum fieldState) {
         if (fieldState != Field::state) {
@@ -26,6 +32,12 @@ namespace spy::scenario {
 
             if (fieldState != FieldStateEnum::SAFE) {
                 Field::safeIndex.reset();
+            }
+
+            if (fieldState == FieldStateEnum::ROULETTE_TABLE) {
+                Field::inverted   = false;
+                Field::destroyed  = false;
+                Field::chipAmount = 0;
             }
         }
     }

--- a/src/datatypes/scenario/Field.hpp
+++ b/src/datatypes/scenario/Field.hpp
@@ -108,6 +108,12 @@ namespace spy::scenario {
             bool operator==(const Field &rhs) const;
 
         private:
+            /**
+             * Initializes the values of optional attributes according to the field type.
+             * @param fieldState Field state.
+             */
+            void initializeOptionals(FieldStateEnum fieldState);
+
             FieldStateEnum state = FieldStateEnum::FREE;
             std::optional<std::shared_ptr<Gadget>> gadget;
             std::optional<bool> destroyed;

--- a/src/datatypes/scenario/Field.hpp
+++ b/src/datatypes/scenario/Field.hpp
@@ -23,6 +23,11 @@ namespace spy::scenario {
             Field() = default;
             explicit Field(FieldStateEnum fieldState);
 
+            /**
+             * Setter for the type of the field.
+             * @param fieldState New field type.
+             * @note  This operation resets the values of the optional attributes according to the field type.
+             */
             void setFieldState(FieldStateEnum fieldState);
 
             /**


### PR DESCRIPTION
Bei der Konstruierung des Feldes wurden in der Field Klasse die optionals nicht initialisiert. Dadurch kam es im Server bei NPC moves dazu, dass in der validateGamble ein bad optional access flog, weil der destroyed Wert nicht gesetzt war. 