### PR TITLE
Änderungen an Katze und Hausmeister

### DIFF
--- a/src/datatypes/character/Character.cpp
+++ b/src/datatypes/character/Character.cpp
@@ -25,7 +25,7 @@ namespace spy::character {
         return coordinates;
     }
 
-    void Character::setCoordinates(const util::Point &coordinate) {
+    void Character::setCoordinates(const std::optional<util::Point> &coordinate) {
         Character::coordinates = coordinate;
     }
 

--- a/src/datatypes/character/Character.hpp
+++ b/src/datatypes/character/Character.hpp
@@ -41,7 +41,7 @@ namespace spy::character {
 
             [[nodiscard]] const std::optional<util::Point> &getCoordinates() const;
 
-            void setCoordinates(const util::Point &coordinates);
+            void setCoordinates(const std::optional<util::Point> &coordinates);
 
             [[nodiscard]] unsigned int getMovePoints() const;
 

--- a/src/gameLogic/execution/ActionExecutor.hpp
+++ b/src/gameLogic/execution/ActionExecutor.hpp
@@ -31,8 +31,6 @@ namespace spy::gameplay {
             static std::shared_ptr<const BaseOperation>
             execute(State &s, std::shared_ptr<const BaseOperation> op, const MatchConfig &config);
 
-        private:
-
             /**
              * Execute Exfiltration
              * @param op Operation to execute, has to be valid

--- a/src/gameLogic/execution/ActionExecutor_Cat.cpp
+++ b/src/gameLogic/execution/ActionExecutor_Cat.cpp
@@ -2,9 +2,20 @@
 // Created by jonas on 28.04.20.
 //
 #include "ActionExecutor.hpp"
+#include "util/GameLogicUtils.hpp"
 
 namespace spy::gameplay {
     std::shared_ptr<const BaseOperation> ActionExecutor::executeCat(State &s, const CatAction &op) {
+        auto targetChar = spy::util::GameLogicUtils::getInCharacterSetByCoordinates(s.getCharacters(), op.getTarget());
+
+        if (targetChar != s.getCharacters().end()) {
+            // white cat and character swap places
+            targetChar->setCoordinates(s.getCatCoordinates().value());
+        } else if (s.getJanitorCoordinates().has_value() && s.getJanitorCoordinates().value() == op.getTarget()) {
+            // white cat and janitor swap places
+            s.setJanitorCoordinates(s.getCatCoordinates().value());
+        }
+
         s.setCatCoordinates(op.getTarget());
 
         auto retOp = std::make_shared<CatAction>(op);

--- a/src/gameLogic/execution/ActionExecutor_Janitor.cpp
+++ b/src/gameLogic/execution/ActionExecutor_Janitor.cpp
@@ -7,8 +7,8 @@
 namespace spy::gameplay {
     std::shared_ptr<const BaseOperation> ActionExecutor::executeJanitor(State &s, const JanitorAction &op) {
         s.setJanitorCoordinates(op.getTarget());
-        util::GameLogicUtils::getInCharacterSetByCoordinates(s.getCharacters(), op.getTarget())->setCoordinates(
-                util::Point{-1, -1});
+        auto character = util::GameLogicUtils::getInCharacterSetByCoordinates(s.getCharacters(), op.getTarget());
+        character->setCoordinates(std::nullopt);
 
         auto retOp = std::make_shared<JanitorAction>(op);
         retOp->setSuccessful(true);

--- a/src/gameLogic/generation/actions/ActionGenerator_Server.cpp
+++ b/src/gameLogic/generation/actions/ActionGenerator_Server.cpp
@@ -19,9 +19,19 @@ namespace spy::gameplay {
     }
 
     std::shared_ptr<BaseOperation> ActionGenerator::generateCatAction(const State &s) {
-        auto target = util::GameLogicUtils::getRandomCharacterFreeNeighbourField(s, s.getCatCoordinates().value());
-        target = target.has_value() ? target : s.getCatCoordinates().value();
-        auto action = std::make_shared<CatAction>(spy::gameplay::CatAction(target.value()));
+        auto targetFields = util::GameLogicUtils::getNearFieldsInDist(s, s.getCatCoordinates().value(), 1,
+                                                                      [&s](const util::Point &p) {
+                                                                          return s.getMap().isAccessible(p);
+                                                                      });
+        util::Point target;
+
+        if (targetFields.second) {
+            target = *util::GameLogicUtils::getRandomItemFromContainer(targetFields.first);
+        } else {
+            target = s.getCatCoordinates().value();
+        }
+
+        auto action = std::make_shared<CatAction>(spy::gameplay::CatAction(target));
         return action;
     }
 
@@ -30,4 +40,5 @@ namespace spy::gameplay {
         auto action = std::make_shared<JanitorAction>(spy::gameplay::JanitorAction(target));
         return action;
     }
+
 }

--- a/test/datatypes/characterSetTest.cpp
+++ b/test/datatypes/characterSetTest.cpp
@@ -88,7 +88,7 @@ TEST_F(CharacterSet, get_uuid_modify) {
     set.insert(c1);
 
     auto c = set.getByUUID(c1.getCharacterId());
-    c->setCoordinates({1, 7});
+    c->setCoordinates(spy::util::Point{1, 7});
     EXPECT_EQ(set.findByUUID(c1.getCharacterId())->getCoordinates(), (spy::util::Point{1, 7}));
 }
 

--- a/test/datatypes/characterTest.cpp
+++ b/test/datatypes/characterTest.cpp
@@ -27,7 +27,7 @@ TEST(Character, json_encode) {
                              spy::character::PropertyEnum::ROBUST_STOMACH,
                              spy::character::PropertyEnum::LUCKY_DEVIL,
                              spy::character::PropertyEnum::TRADECRAFT});
-    character.setCoordinates({0,0});
+    character.setCoordinates(spy::util::Point{0,0});
 
     nlohmann::json characterJson = character;
 
@@ -46,7 +46,7 @@ TEST(Character, json_decode) {
                              spy::character::PropertyEnum::ROBUST_STOMACH,
                              spy::character::PropertyEnum::LUCKY_DEVIL,
                              spy::character::PropertyEnum::TRADECRAFT});
-    character.setCoordinates({0,0});
+    character.setCoordinates(spy::util::Point{0,0});
 
     EXPECT_EQ(character.getCharacterId().to_string(), decodedCharacter.getCharacterId().to_string());
     EXPECT_EQ(character.getName(), decodedCharacter.getName());

--- a/test/gameLogic/gadget/chickenFeedTests.cpp
+++ b/test/gameLogic/gadget/chickenFeedTests.cpp
@@ -18,11 +18,11 @@ TEST_F(GadgetActionTests, ChickenFeed_Validate) {
 
     auto chickenFeed = std::make_shared<Gadget>(spy::gadget::GadgetEnum::CHICKEN_FEED);
 
-    state.getCharacters().getByUUID(uuid1)->setCoordinates({4, 3});
-    state.getCharacters().getByUUID(uuid2)->setCoordinates({5, 3});
-    state.getCharacters().getByUUID(uuid3)->setCoordinates({4, 2});
-    state.getCharacters().getByUUID(uuid4)->setCoordinates({4, 5});
-    state.getCharacters().getByUUID(uuid5)->setCoordinates({6, 6});
+    state.getCharacters().getByUUID(uuid1)->setCoordinates(Point{4, 3});
+    state.getCharacters().getByUUID(uuid2)->setCoordinates(Point{5, 3});
+    state.getCharacters().getByUUID(uuid3)->setCoordinates(Point{4, 2});
+    state.getCharacters().getByUUID(uuid4)->setCoordinates(Point{4, 5});
+    state.getCharacters().getByUUID(uuid5)->setCoordinates(Point{6, 6});
 
     state.getCharacters().getByUUID(uuid1)->addGadget(chickenFeed);
     state.getCharacters().getByUUID(uuid5)->addGadget(chickenFeed);

--- a/test/gameLogic/gadget/cocktailTests.cpp
+++ b/test/gameLogic/gadget/cocktailTests.cpp
@@ -19,11 +19,11 @@ TEST_F(GadgetActionTests, Cocktail_Validate) {
 
     auto cocktail = std::make_shared<spy::gadget::Cocktail>();
 
-    state.getCharacters().getByUUID(uuid1)->setCoordinates({4, 3});
-    state.getCharacters().getByUUID(uuid2)->setCoordinates({5, 3});
-    state.getCharacters().getByUUID(uuid3)->setCoordinates({4, 2});
-    state.getCharacters().getByUUID(uuid4)->setCoordinates({4, 5});
-    state.getCharacters().getByUUID(uuid5)->setCoordinates({6, 6});
+    state.getCharacters().getByUUID(uuid1)->setCoordinates(Point{4, 3});
+    state.getCharacters().getByUUID(uuid2)->setCoordinates(Point{5, 3});
+    state.getCharacters().getByUUID(uuid3)->setCoordinates(Point{4, 2});
+    state.getCharacters().getByUUID(uuid4)->setCoordinates(Point{4, 5});
+    state.getCharacters().getByUUID(uuid5)->setCoordinates(Point{6, 6});
 
     state.getCharacters().getByUUID(uuid1)->addGadget(cocktail);
     state.getCharacters().getByUUID(uuid5)->addGadget(cocktail);

--- a/test/gameLogic/gadget/diamondCollarTests.cpp
+++ b/test/gameLogic/gadget/diamondCollarTests.cpp
@@ -18,10 +18,10 @@ TEST_F(GadgetActionTests, DiamondCollar_Validate) {
 
     auto collar = std::make_shared<Gadget>(spy::gadget::GadgetEnum::DIAMOND_COLLAR);
 
-    state.getCharacters().getByUUID(uuid1)->setCoordinates({4, 3});
-    state.getCharacters().getByUUID(uuid2)->setCoordinates({5, 3});
-    state.getCharacters().getByUUID(uuid3)->setCoordinates({5, 2});
-    state.getCharacters().getByUUID(uuid5)->setCoordinates({6, 6});
+    state.getCharacters().getByUUID(uuid1)->setCoordinates(Point{4, 3});
+    state.getCharacters().getByUUID(uuid2)->setCoordinates(Point{5, 3});
+    state.getCharacters().getByUUID(uuid3)->setCoordinates(Point{5, 2});
+    state.getCharacters().getByUUID(uuid5)->setCoordinates(Point{6, 6});
 
     state.setCatCoordinates(Point{4, 4});
 

--- a/test/gameLogic/gadget/gasGlossTests.cpp
+++ b/test/gameLogic/gadget/gasGlossTests.cpp
@@ -18,11 +18,11 @@ TEST_F(GadgetActionTests, GasGloss_Validate) {
 
     auto gloss = std::make_shared<Gadget>(GadgetEnum::GAS_GLOSS);
 
-    state.getCharacters().getByUUID(uuid1)->setCoordinates({4, 3});
-    state.getCharacters().getByUUID(uuid2)->setCoordinates({5, 3});
-    state.getCharacters().getByUUID(uuid3)->setCoordinates({4, 2});
-    state.getCharacters().getByUUID(uuid4)->setCoordinates({4, 5});
-    state.getCharacters().getByUUID(uuid5)->setCoordinates({6, 6});
+    state.getCharacters().getByUUID(uuid1)->setCoordinates(Point{4, 3});
+    state.getCharacters().getByUUID(uuid2)->setCoordinates(Point{5, 3});
+    state.getCharacters().getByUUID(uuid3)->setCoordinates(Point{4, 2});
+    state.getCharacters().getByUUID(uuid4)->setCoordinates(Point{4, 5});
+    state.getCharacters().getByUUID(uuid5)->setCoordinates(Point{6, 6});
 
     state.getCharacters().getByUUID(uuid1)->addGadget(gloss);
     state.getCharacters().getByUUID(uuid5)->addGadget(gloss);

--- a/test/gameLogic/gadget/hairdryerTests.cpp
+++ b/test/gameLogic/gadget/hairdryerTests.cpp
@@ -20,11 +20,11 @@ TEST_F(GadgetActionTests, Hairdryer_Validate) {
 
     auto hairdryer = std::make_shared<Gadget>(GadgetEnum::HAIRDRYER);
 
-    state.getCharacters().getByUUID(uuid1)->setCoordinates({4, 3});
-    state.getCharacters().getByUUID(uuid2)->setCoordinates({4, 2});
-    state.getCharacters().getByUUID(uuid3)->setCoordinates({4, 4});
-    state.getCharacters().getByUUID(uuid4)->setCoordinates({5, 3});
-    state.getCharacters().getByUUID(uuid5)->setCoordinates({6, 6});
+    state.getCharacters().getByUUID(uuid1)->setCoordinates(Point{4, 3});
+    state.getCharacters().getByUUID(uuid2)->setCoordinates(Point{4, 2});
+    state.getCharacters().getByUUID(uuid3)->setCoordinates(Point{4, 4});
+    state.getCharacters().getByUUID(uuid4)->setCoordinates(Point{5, 3});
+    state.getCharacters().getByUUID(uuid5)->setCoordinates(Point{6, 6});
 
     state.getCharacters().getByUUID(uuid1)->addGadget(hairdryer);
     state.getCharacters().getByUUID(uuid5)->addGadget(hairdryer);
@@ -58,9 +58,10 @@ TEST_F(GadgetActionTests, HairDryer_Execute) {
     using spy::character::PropertyEnum;
     using spy::gameplay::ActionExecutor;
     using spy::gameplay::GadgetAction;
+    using spy::util::Point;
 
-    state.getCharacters().getByUUID(uuid1)->setCoordinates({1, 2});
-    state.getCharacters().getByUUID(uuid2)->setCoordinates({2, 2});
+    state.getCharacters().getByUUID(uuid1)->setCoordinates(Point{1, 2});
+    state.getCharacters().getByUUID(uuid2)->setCoordinates(Point{2, 2});
 
     auto c1 = state.getCharacters().getByUUID(uuid1);
     auto c2 = state.getCharacters().getByUUID(uuid2);

--- a/test/gameLogic/gadget/jetpackTests.cpp
+++ b/test/gameLogic/gadget/jetpackTests.cpp
@@ -18,10 +18,10 @@ TEST_F(GadgetActionTests, Jetpack_Validate) {
 
     auto jetpack = std::make_shared<Gadget>(GadgetEnum::JETPACK);
 
-    state.getCharacters().getByUUID(uuid1)->setCoordinates({4, 3});
-    state.getCharacters().getByUUID(uuid2)->setCoordinates({5, 3});
-    state.getCharacters().getByUUID(uuid3)->setCoordinates({4, 2});
-    state.getCharacters().getByUUID(uuid5)->setCoordinates({6, 6});
+    state.getCharacters().getByUUID(uuid1)->setCoordinates(Point{4, 3});
+    state.getCharacters().getByUUID(uuid2)->setCoordinates(Point{5, 3});
+    state.getCharacters().getByUUID(uuid3)->setCoordinates(Point{4, 2});
+    state.getCharacters().getByUUID(uuid5)->setCoordinates(Point{6, 6});
 
     state.getCharacters().getByUUID(uuid1)->addGadget(jetpack);
     state.getCharacters().getByUUID(uuid5)->addGadget(jetpack);

--- a/test/gameLogic/gadget/nuggetTests.cpp
+++ b/test/gameLogic/gadget/nuggetTests.cpp
@@ -18,13 +18,13 @@ TEST_F(GadgetActionTests, Nugget_Validate) {
 
     auto nugget = std::make_shared<Gadget>(GadgetEnum::NUGGET);
 
-    state.getCharacters().getByUUID(uuid1)->setCoordinates({4, 3});
-    state.getCharacters().getByUUID(uuid2)->setCoordinates({5, 3});
+    state.getCharacters().getByUUID(uuid1)->setCoordinates(Point{4, 3});
+    state.getCharacters().getByUUID(uuid2)->setCoordinates(Point{5, 3});
     state.getCharacters().getByUUID(uuid2)->setFaction(spy::character::FactionEnum::PLAYER2);
-    state.getCharacters().getByUUID(uuid3)->setCoordinates({4, 2});
+    state.getCharacters().getByUUID(uuid3)->setCoordinates(Point{4, 2});
     state.getCharacters().getByUUID(uuid3)->setFaction(spy::character::FactionEnum::PLAYER1);
-    state.getCharacters().getByUUID(uuid4)->setCoordinates({4, 5});
-    state.getCharacters().getByUUID(uuid5)->setCoordinates({6, 6});
+    state.getCharacters().getByUUID(uuid4)->setCoordinates(Point{4, 5});
+    state.getCharacters().getByUUID(uuid5)->setCoordinates(Point{6, 6});
 
     state.getCharacters().getByUUID(uuid1)->addGadget(nugget);
     state.getCharacters().getByUUID(uuid1)->setFaction(spy::character::FactionEnum::PLAYER1);

--- a/test/gameLogic/gadget/poisonPillTests.cpp
+++ b/test/gameLogic/gadget/poisonPillTests.cpp
@@ -19,13 +19,13 @@ TEST_F(GadgetActionTests, PoisonPills_Validate) {
     auto poisonPills = std::make_shared<Gadget>(GadgetEnum::POISON_PILLS);
     auto cocktail    = std::make_shared<Gadget>(GadgetEnum::COCKTAIL);
 
-    state.getCharacters().getByUUID(uuid1)->setCoordinates({4, 3});
-    state.getCharacters().getByUUID(uuid2)->setCoordinates({5, 3});
-    state.getCharacters().getByUUID(uuid3)->setCoordinates({4, 2});
-    state.getCharacters().getByUUID(uuid4)->setCoordinates({4, 5});
-    state.getCharacters().getByUUID(uuid5)->setCoordinates({6, 6});
-    state.getCharacters().getByUUID(uuid6)->setCoordinates({1, 2});
-    state.getCharacters().getByUUID(uuid7)->setCoordinates({4, 1});
+    state.getCharacters().getByUUID(uuid1)->setCoordinates(Point{4, 3});
+    state.getCharacters().getByUUID(uuid2)->setCoordinates(Point{5, 3});
+    state.getCharacters().getByUUID(uuid3)->setCoordinates(Point{4, 2});
+    state.getCharacters().getByUUID(uuid4)->setCoordinates(Point{4, 5});
+    state.getCharacters().getByUUID(uuid5)->setCoordinates(Point{6, 6});
+    state.getCharacters().getByUUID(uuid6)->setCoordinates(Point{1, 2});
+    state.getCharacters().getByUUID(uuid7)->setCoordinates(Point{4, 1});
 
     state.getCharacters().getByUUID(uuid1)->addGadget(poisonPills);
     state.getCharacters().getByUUID(uuid1)->addGadget(cocktail);

--- a/test/gameLogic/gadget/technicolourPrismTests.cpp
+++ b/test/gameLogic/gadget/technicolourPrismTests.cpp
@@ -18,10 +18,10 @@ TEST_F(GadgetActionTests, TechnicolourPrism_Validate) {
 
     auto prism = std::make_shared<Gadget>(GadgetEnum::TECHNICOLOUR_PRISM);
 
-    state.getCharacters().getByUUID(uuid1)->setCoordinates({4, 3});
-    state.getCharacters().getByUUID(uuid2)->setCoordinates({5, 3});
-    state.getCharacters().getByUUID(uuid3)->setCoordinates({3, 2});
-    state.getCharacters().getByUUID(uuid5)->setCoordinates({6, 6});
+    state.getCharacters().getByUUID(uuid1)->setCoordinates(Point{4, 3});
+    state.getCharacters().getByUUID(uuid2)->setCoordinates(Point{5, 3});
+    state.getCharacters().getByUUID(uuid3)->setCoordinates(Point{3, 2});
+    state.getCharacters().getByUUID(uuid5)->setCoordinates(Point{6, 6});
 
     state.getCharacters().getByUUID(uuid1)->addGadget(prism);
     state.getCharacters().getByUUID(uuid5)->addGadget(prism);

--- a/test/gameLogic/gadget/wiretapWithEarplugsTests.cpp
+++ b/test/gameLogic/gadget/wiretapWithEarplugsTests.cpp
@@ -19,13 +19,13 @@ TEST_F(GadgetActionTests, WiretapWithEarplugs_Validate) {
 
     auto earplugs = std::make_shared<spy::gadget::WiretapWithEarplugs>();
 
-    state.getCharacters().getByUUID(uuid1)->setCoordinates({4, 3});
-    state.getCharacters().getByUUID(uuid2)->setCoordinates({5, 3});
+    state.getCharacters().getByUUID(uuid1)->setCoordinates(Point{4, 3});
+    state.getCharacters().getByUUID(uuid2)->setCoordinates(Point{5, 3});
     state.getCharacters().getByUUID(uuid2)->setFaction(spy::character::FactionEnum::PLAYER2);
-    state.getCharacters().getByUUID(uuid3)->setCoordinates({4, 2});
+    state.getCharacters().getByUUID(uuid3)->setCoordinates(Point{4, 2});
     state.getCharacters().getByUUID(uuid3)->setFaction(spy::character::FactionEnum::PLAYER1);
-    state.getCharacters().getByUUID(uuid4)->setCoordinates({4, 5});
-    state.getCharacters().getByUUID(uuid5)->setCoordinates({6, 6});
+    state.getCharacters().getByUUID(uuid4)->setCoordinates(Point{4, 5});
+    state.getCharacters().getByUUID(uuid5)->setCoordinates(Point{6, 6});
 
     state.getCharacters().getByUUID(uuid1)->addGadget(earplugs);
     state.getCharacters().getByUUID(uuid1)->setFaction(spy::character::FactionEnum::PLAYER1);

--- a/test/gameLogic/movementTests.cpp
+++ b/test/gameLogic/movementTests.cpp
@@ -104,12 +104,13 @@ TEST_F(MovementOperation, isMovementValid) {
     using spy::character::Character;
     using spy::character::CharacterSet;
     using spy::util::UUID;
+    using spy::util::Point;
     using spy::gameplay::Movement;
     using spy::gameplay::State;
     using spy::gameplay::ActionValidator;
 
-    state.getCharacters().getByUUID(uuid1)->setCoordinates({1, 2});
-    state.getCharacters().getByUUID(uuid2)->setCoordinates({1, 5});
+    state.getCharacters().getByUUID(uuid1)->setCoordinates(Point{1, 2});
+    state.getCharacters().getByUUID(uuid2)->setCoordinates(Point{1, 5});
 
     auto move1 = std::make_shared<Movement>(Movement(false, {1, 1}, uuid1, {1, 2}));
     auto move2 = std::make_shared<Movement>(Movement(false, {1, 3}, uuid1, {1, 2}));
@@ -139,7 +140,7 @@ TEST_F(MovementOperation, Movement) {
     using spy::util::Point;
     using spy::gameplay::ActionExecutor;
 
-    state.getCharacters().getByUUID(uuid1)->setCoordinates({1, 2});
+    state.getCharacters().getByUUID(uuid1)->setCoordinates(Point{1, 2});
 
     auto move1 = std::make_shared<Movement>(Movement(false, {2, 2}, uuid1, {1, 2}));
     auto move2 = std::make_shared<Movement>(Movement(false, {3, 2}, uuid1, {2, 2}));
@@ -168,11 +169,11 @@ TEST_F(MovementOperation, MovementSwap) {
     using spy::util::Point;
     using spy::gameplay::ActionExecutor;
 
-    state.getCharacters().getByUUID(uuid1)->setCoordinates({1, 2});
-    state.getCharacters().getByUUID(uuid2)->setCoordinates({2, 2});
-    state.getCharacters().getByUUID(uuid3)->setCoordinates({3, 2});
-    state.getCharacters().getByUUID(uuid4)->setCoordinates({4, 3});
-    state.getCharacters().getByUUID(uuid5)->setCoordinates({4, 4});
+    state.getCharacters().getByUUID(uuid1)->setCoordinates(Point{1, 2});
+    state.getCharacters().getByUUID(uuid2)->setCoordinates(Point{2, 2});
+    state.getCharacters().getByUUID(uuid3)->setCoordinates(Point{3, 2});
+    state.getCharacters().getByUUID(uuid4)->setCoordinates(Point{4, 3});
+    state.getCharacters().getByUUID(uuid5)->setCoordinates(Point{4, 4});
 
     auto move1 = std::make_shared<Movement>(Movement(false, {2, 2}, uuid1, {1, 2}));
     auto move2 = std::make_shared<Movement>(Movement(false, {3, 2}, uuid1, {2, 2}));
@@ -226,6 +227,7 @@ TEST_F(MovementOperation, MovementSwap) {
 TEST_F(MovementOperation, MovementGadget) {
     using spy::gameplay::Movement;
     using spy::gameplay::ActionExecutor;
+    using spy::util::Point;
 
     state.getMap().getField({2, 2}).setGadget(g1);
     state.getMap().getField({3, 2}).setGadget(g2);
@@ -233,7 +235,7 @@ TEST_F(MovementOperation, MovementGadget) {
     state.getMap().getField({4, 4}).setGadget(g4);
     state.getMap().getField({5, 3}).setGadget(g5);
 
-    state.getCharacters().getByUUID(uuid1)->setCoordinates({1, 2});
+    state.getCharacters().getByUUID(uuid1)->setCoordinates(Point{1, 2});
 
     auto move1 = std::make_shared<Movement>(Movement(false, {2, 2}, uuid1, {1, 2}));
     auto move2 = std::make_shared<Movement>(Movement(false, {3, 2}, uuid1, {2, 2}));
@@ -345,7 +347,7 @@ TEST_F(MovementOperation, MovementCatJanitor) {
     using spy::gameplay::ActionExecutor;
     using spy::util::Point;
 
-    state.getCharacters().getByUUID(uuid1)->setCoordinates({1, 2});
+    state.getCharacters().getByUUID(uuid1)->setCoordinates(Point{1, 2});
     state.setCatCoordinates(Point{2, 2});
     state.setJanitorCoordinates(Point{3, 2});
 


### PR DESCRIPTION
Die weiße Katze kann nun auch Felder betreten, auf denen ein Charakter oder der Hausmeister steht.

Beim Hausmeister wurde das Entfernen von Charakteren mittels std::nullopt statt einem Punkt außerhalb des Spielfeldes gemacht. 
Die Implementierung lässt das zu, wurde lediglich im Setter blockiert. 