### PR TITLE
State combinations setter

### DIFF
--- a/src/datatypes/gameplay/State.cpp
+++ b/src/datatypes/gameplay/State.cpp
@@ -127,4 +127,8 @@ namespace spy::gameplay {
     void State::addSafeCombination(unsigned int safe) {
         mySafeCombinations.insert(safe);
     }
+
+    void State::setKnownSafeCombinations(std::set<int> combinations) {
+        mySafeCombinations = combinations;
+    }
 }

--- a/src/datatypes/gameplay/State.cpp
+++ b/src/datatypes/gameplay/State.cpp
@@ -131,4 +131,8 @@ namespace spy::gameplay {
     void State::setKnownSafeCombinations(std::set<int> combinations) {
         mySafeCombinations = combinations;
     }
+
+    void State::incrementRoundCounter() {
+        currentRound++;
+    }
 }

--- a/src/datatypes/gameplay/State.hpp
+++ b/src/datatypes/gameplay/State.hpp
@@ -78,6 +78,8 @@ namespace spy::gameplay {
 
             void setKnownSafeCombinations(std::set<int> combinations);
 
+            void incrementRoundCounter();
+
             friend void to_json(nlohmann::json &j, const State &s);
 
             friend void from_json(const nlohmann::json &j, State &s);

--- a/src/datatypes/gameplay/State.hpp
+++ b/src/datatypes/gameplay/State.hpp
@@ -76,6 +76,8 @@ namespace spy::gameplay {
 
             void addSafeCombination(unsigned int safe);
 
+            void setKnownSafeCombinations(std::set<int> combinations);
+
             friend void to_json(nlohmann::json &j, const State &s);
 
             friend void from_json(const nlohmann::json &j, State &s);

--- a/src/gameLogic/execution/ActionExecutor_Spy.cpp
+++ b/src/gameLogic/execution/ActionExecutor_Spy.cpp
@@ -59,6 +59,12 @@ namespace spy::gameplay {
         // get index of safe
         auto safeIndex = s.getMap().getField(op.getTarget()).getSafeIndex().value();
 
+        if (s.getMySafeCombinations().find(safeIndex) == s.getMySafeCombinations().end()) {
+            // character lacks the safe combination --> safe cannot be opened
+            retOp->setSuccessful(false);
+            return retOp;
+        }
+
         // query safe indexes and the collar location from the current state
         unsigned int maxSafeIndex = 1;
         bool collarOnMap = false;
@@ -80,12 +86,6 @@ namespace spy::gameplay {
                     break;
                 }
             }
-        }
-
-        if (s.getMySafeCombinations().find(safeIndex) == s.getMySafeCombinations().end()) {
-            // character lacks the safe combination --> safe cannot be opened
-            retOp->setSuccessful(false);
-            return retOp;
         }
 
         if (safeIndex == maxSafeIndex && !collarOnMap) {


### PR DESCRIPTION
Der Server muss in der Lage sein, die bekannten Safe Kombinationen entsprechend des Spielers zu setzen, daher wurde ein neuer Setter ergänzt.
Zusätzlich wurde bei der Ausführung der Spy Action die Überprüfung dieser Kombination weiter nach vorne verschoben.