### PR TITLE
fixed version of nlohmann::json

### DIFF
--- a/installDependencies.sh
+++ b/installDependencies.sh
@@ -9,10 +9,8 @@ sudo apt install -y uuid-dev
 
 # nlohmann json
 cd /tmp
-git clone --depth 1 --branch master https://github.com/nlohmann/json.git
+git clone --depth 1 -b v3.7.3 https://github.com/nlohmann/json.git
 cd json
-git fetch origin 456478b3c50d60100dbb1fb9bc931f370a2c1c28
-git checkout 456478b3c50d60100dbb1fb9bc931f370a2c1c28
 mkdir build && cd build
 cmake -DJSON_BuildTests=false ..
 make -j$(nproc)

--- a/installDependencies.sh
+++ b/installDependencies.sh
@@ -9,8 +9,10 @@ sudo apt install -y uuid-dev
 
 # nlohmann json
 cd /tmp
-git clone --depth 1 https://github.com/nlohmann/json.git
+git clone --depth 1 --branch master https://github.com/nlohmann/json.git
 cd json
+git fetch origin 456478b3c50d60100dbb1fb9bc931f370a2c1c28
+git checkout 456478b3c50d60100dbb1fb9bc931f370a2c1c28
 mkdir build && cd build
 cmake -DJSON_BuildTests=false ..
 make -j$(nproc)


### PR DESCRIPTION
Currently the develop branch of nlohmann::json was used, but some new commits broke the CI. 
Version is now fixed to the current master commit.

TODO:

- [x] test if CI works with this commit