### PR TITLE
character fix: add missing .end in erase(remove_if(...)...)

### DIFF
--- a/src/datatypes/character/Character.cpp
+++ b/src/datatypes/character/Character.cpp
@@ -182,7 +182,7 @@ namespace spy::character {
     void Character::removeGadget(gadget::GadgetEnum gadget) {
         gadgets.erase(std::remove_if(gadgets.begin(), gadgets.end(), [gadget](std::shared_ptr<gadget::Gadget> g) {
             return g->getType() == gadget;
-        }));
+        }), gadgets.end());
     }
 
     bool Character::hasGadget(spy::gadget::GadgetEnum type) const {


### PR DESCRIPTION
Fixt komische edgecases wo das:
![DeepinScreenshot_select-area_20200611225024](https://user-images.githubusercontent.com/7536298/84437872-00cf0480-ac36-11ea-9d84-deaec0152545.png)
passiert. Hoch lebe C++! Hoch lebe das erase-remove idiom!