### PR TITLE
Mirror of Wilderness Fix

### DIFF
--- a/src/datatypes/gadgets/Gadget.cpp
+++ b/src/datatypes/gadgets/Gadget.cpp
@@ -45,6 +45,8 @@ namespace spy::gadget {
                 [[fallthrough]];
             case GadgetEnum::COCKTAIL:
                 [[fallthrough]];
+            case GadgetEnum::MIRROR_OF_WILDERNESS:
+                [[fallthrough]];
             case GadgetEnum::FOG_TIN:
                 usagesLeft = 1;
                 break;


### PR DESCRIPTION
Fixes #319 

Die usages wurden jetzt auf 1 gesetzt, dass entspricht dem, dass der Spiegel bei der Anwendung auf einen Charakter zerspringt. Für die eigene Fraktion passt die Sonderbehandlung in der Execution